### PR TITLE
Fix double major course handling and modal behavior

### DIFF
--- a/s_curriculum.js
+++ b/s_curriculum.js
@@ -1124,12 +1124,12 @@ function s_curriculum()
                         dmType = dmStaticType;
                     }
                 } else {
-                    // Unknown course: treat as free elective but use any
-                    // credit value attached to the course object (e.g., from
-                    // primary catalog) to count towards DM totals.
+                    // Unknown course in the double major catalog: do not
+                    // allocate it to any DM category. Still count its credit
+                    // values for science/engineering/ECTS tracking.
                     credit = parseInt(course.credit || course.SU_credit || '0');
-                    dmType = 'free';
-                    dmStaticType = 'free';
+                    dmType = 'none';
+                    dmStaticType = 'none';
                 }
                 // Assign DM effective type
                 course.effective_type_dm = dmType;


### PR DESCRIPTION
## Summary
- keep DM-only courses when reloading by preloading DM data
- prevent accidental closing of custom course and DM category modals
- remove cancel option from DM category selection
- close import panel after importing records
- count courses missing from DM catalog as `none`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6889d4d66534832aa24b8744da9a6ecd