### PR TITLE
Fix grade change allocation and ignore repeated transcript entries

### DIFF
--- a/click.js
+++ b/click.js
@@ -338,7 +338,16 @@ function dynamic_click(e, curriculum, course_data)
             }
             prevGrade = grade;
             e.target.parentNode.innerHTML = grade;
-            
+
+            // Recalculate effective categories when the grade changes so
+            // that courses that were previously failed (F) or newly
+            // passed are allocated correctly.
+            try {
+                if (typeof curriculum.recalcEffectiveTypes === 'function') {
+                    curriculum.recalcEffectiveTypes(course_data);
+                }
+            } catch (_) {}
+
             //alert(curriculum.getSemester(sem.id).totalGPA / curriculum.getSemester(sem.id).totalGPACredits)
         })
     }


### PR DESCRIPTION
## Summary
- recalc effective categories after a grade is edited
- ignore courses marked as `Repeated` or `Excluded` when importing transcripts
- only keep the last occurrence of a course code during transcript import

## Testing
- `node -c academic_records_parser.js`
- `node -c click.js`
- `python3 -m py_compile fetch_courses.py update_credits.py`


------
https://chatgpt.com/codex/tasks/task_e_688a04c88ca8832aa49d9dfc843843f0