### PR TITLE
Improve grade handling

### DIFF
--- a/academic_records_parser.js
+++ b/academic_records_parser.js
@@ -31,16 +31,6 @@ function parseAcademicRecords(htmlContent) {
         const semesterHeader = table.querySelector('thead tr th:first-child b');
         let semester = semesterHeader ? semesterHeader.textContent.trim() : "Unknown Semester";
 
-        // Skip if the semester is a future or current semester with registered courses
-        if (semester.includes("Registered") || table.textContent.includes("Registered")) {
-            const hasRegisteredOnly = Array.from(table.querySelectorAll('tbody tr'))
-                .filter(row => {
-                    const cells = row.querySelectorAll('td');
-                    return cells.length >= 4 && cells[3].textContent.trim() !== "Registered";
-                }).length === 0;
-
-            if (hasRegisteredOnly) return;
-        }
 
         // Get all course rows (skip header rows and special rows)
         const courseRows = Array.from(table.querySelectorAll('tbody tr')).filter(row => {
@@ -109,17 +99,20 @@ function parseAcademicRecords(htmlContent) {
                     return; // Skip this iteration
                 }
 
-                // Only include courses with passing grades or F (exclude W, NA and Registered)
-                if (!['W', 'NA', 'Registered'].includes(grade)) {
-                    latestMap[courseCode] = {
-                        code: courseCode,
-                        title: courseTitle,
-                        grade: grade,
-                        semester: semester,
-                        suCredits: suCredits,
-                        ects: ects
-                    };
+                // Skip withdrawn or not attended courses
+                if (['W', 'NA'].includes(grade)) {
+                    return;
                 }
+
+                // Include the course, using blank grade for "Registered"
+                latestMap[courseCode] = {
+                    code: courseCode,
+                    title: courseTitle,
+                    grade: grade === 'Registered' ? '' : grade,
+                    semester: semester,
+                    suCredits: suCredits,
+                    ects: ects
+                };
             }
         });
     });

--- a/click.js
+++ b/click.js
@@ -346,9 +346,39 @@ function dynamic_click(e, curriculum, course_data)
                 if (typeof curriculum.recalcEffectiveTypes === 'function') {
                     curriculum.recalcEffectiveTypes(course_data);
                 }
+                if (typeof curriculum.recalcEffectiveTypesDouble === 'function' && curriculum.doubleMajor) {
+                    curriculum.recalcEffectiveTypesDouble(curriculum.doubleMajorCourseData);
+                }
             } catch (_) {}
 
             //alert(curriculum.getSemester(sem.id).totalGPA / curriculum.getSemester(sem.id).totalGPACredits)
-        })
+        });
+
+        // Allow leaving the grade empty by blurring the input
+        input.addEventListener('blur', function(e){
+            const val = input.value.trim();
+            if(!val){
+                let sem = input.parentNode.parentNode.parentNode.parentNode;
+                let courseName = input.parentNode.parentNode.querySelector('.course_label').firstChild.innerHTML;
+                let semObj = curriculum.getSemester(sem.id);
+                // If there was a previous grade remove its effects already subtracted above
+                if(prevGrade === 'F'){
+                    let info = getInfo(courseName, course_data);
+                    adjustSemesterTotals(semObj, info, 1);
+                }
+                input.parentNode.style.fontSize = '';
+                input.parentNode.style.paddingRight = '7px';
+                input.parentNode.style.paddingBottom = '';
+                input.parentNode.innerHTML = 'Add grade';
+                try{
+                    if (typeof curriculum.recalcEffectiveTypes === 'function') {
+                        curriculum.recalcEffectiveTypes(course_data);
+                    }
+                    if (typeof curriculum.recalcEffectiveTypesDouble === 'function' && curriculum.doubleMajor) {
+                        curriculum.recalcEffectiveTypesDouble(curriculum.doubleMajorCourseData);
+                    }
+                }catch(_){}
+            }
+        });
     }
 }


### PR DESCRIPTION
## Summary
- parse transcript to keep "Registered" courses with empty grade
- allow empty grade inputs to revert back to "Add grade"
- update double major categories whenever grades change

## Testing
- `node --check academic_records_parser.js`
- `node --check click.js`


------
https://chatgpt.com/codex/tasks/task_e_688a0caef8a8832a9ca312806bf3ea06