### PR TITLE
Improve fetching scripts and UI limits

### DIFF
--- a/fetch_requirements.py
+++ b/fetch_requirements.py
@@ -3,9 +3,12 @@ import requests
 from bs4 import BeautifulSoup
 import os
 import datetime
+import re
 
 REQUIREMENTS_DIR = 'requirements'
 BASE = 'https://suis.sabanciuniv.edu/prod/'
+# Local directory with saved degree detail pages for testing without network
+DETAIL_PAGES_DIR = 'Degree Detail Pages (for inspect)'
 
 PROGRAM_CODES = {
     'BSBIO': 'BIO',
@@ -22,41 +25,79 @@ PROGRAM_CODES = {
     'BAVACD': 'VACD',
 }
 
-def fetch_requirements(program, term):
-    url = (BASE + 'SU_DEGREE.p_degree_detail?P_PROGRAM={p}&P_LANG=EN&P_LEVEL=UG&P_TERM={t}&P_SUBMIT=Select').format(p=program, t=term)
-    resp = requests.get(url)
-    resp.raise_for_status()
-    soup = BeautifulSoup(resp.text, 'lxml')
-    table = soup.find('table')
+def fetch_requirements(program, term, offline_dir=None):
+    """Fetch requirement summary for a program and term.
+
+    When ``offline_dir`` is provided and contains a saved HTML page for the
+    program, that file is parsed instead of performing a network request.
+    Returns a dict with ``ects`` and ``total`` keys if found.
+    """
+
+    html = None
+    major = PROGRAM_CODES.get(program, program)
+    if offline_dir:
+        fname = f'SU_DEGREE.p_degree_detail_{major}.html'
+        fpath = os.path.join(offline_dir, fname)
+        if os.path.exists(fpath):
+            with open(fpath, 'r', encoding='utf-8') as fh:
+                html = fh.read()
+
+    if html is None:
+        url = (
+            BASE +
+            'SU_DEGREE.p_degree_detail?P_PROGRAM={p}&P_LANG=EN&P_LEVEL=UG&P_TERM={t}&P_SUBMIT=Select'
+        ).format(p=program, t=term)
+        resp = requests.get(url)
+        resp.raise_for_status()
+        html = resp.text
+
+    soup = BeautifulSoup(html, 'lxml')
+    # Summary table usually has class "t_mezuniyet"; fall back to the first
+    # table containing "SUMMARY OF DEGREE" text.
+    table = soup.find('table', class_='t_mezuniyet')
+    if not table:
+        h1 = soup.find('h1', string=lambda s: s and 'SUMMARY OF DEGREE' in s)
+        if h1:
+            table = h1.find_parent('table')
     req = {}
     if not table:
         return req
-    rows = table.find_all('tr')
-    for r in rows:
-        cols = [c.get_text(strip=True) for c in r.find_all('td')]
-        if len(cols) >= 2:
-            key = cols[0].lower()
-            val = cols[1]
-            if 'ects' in key:
-                req['ects'] = int(val)
-            elif 'su credit' in key and 'total' in key:
-                req['total'] = int(val)
+
+    headers = [th.get_text(strip=True).lower() for th in table.select('thead th')]
+    for tr in table.find_all('tr'):
+        tds = [td.get_text(strip=True) for td in tr.find_all('td')]
+        if tds and re.search(r'total', tds[0], re.I):
+            for i, hdr in enumerate(headers[1:], start=1):
+                if i >= len(tds):
+                    continue
+                val = tds[i]
+                if 'ects' in hdr:
+                    req['ects'] = int(re.search(r'\d+', val).group())
+                elif 'su' in hdr:
+                    req['total'] = int(re.search(r'\d+', val).group())
+            break
     return req
 
 def main():
     os.makedirs(REQUIREMENTS_DIR, exist_ok=True)
-    cur_year = datetime.datetime.now().year
+    # Generate term codes starting from 2019 up to Fall 2025 only.
     terms = []
-    for year in range(2019, cur_year + 3):
-        for suf in ('01','02','03'):
+    for year in range(2019, 2026):
+        suffixes = ('01', '02', '03')
+        if year == 2025:
+            suffixes = ('01',)  # Only Fall 2025 should be scraped
+        for suf in suffixes:
             terms.append(f"{year}{suf}")
 
     for term in terms:
         out = {}
         for prog, major in PROGRAM_CODES.items():
             try:
-                data = fetch_requirements(prog, term)
-            except Exception:
+                data = fetch_requirements(prog, term, DETAIL_PAGES_DIR)
+                if not data:
+                    raise ValueError('no data parsed')
+            except Exception as e:
+                print(f"Failed {major} {term}: {e}")
                 data = {}
             if data:
                 out[major] = data

--- a/helper_functions.js
+++ b/helper_functions.js
@@ -82,20 +82,24 @@ if (currentMonth >= 7) { // August or later
 // past and future relative to the current academic year but never go earlier
 // than 2019 so that the earliest selectable term matches the scraped data.
 const startYear = Math.max(2019, academicYear - 6);
-const endYear = academicYear + 6;
+const endYear = Math.min(2025, academicYear + 6);
 for (let i = startYear; i <= endYear; i++) {
     // Create academic year string (e.g., "2022-2023")
     let yearRange = i + "-" + (i + 1);
 
-    // Add Spring, Fall, and optionally Summer to the list
-    date_list_InnerHTML += "<option value='" + yearRange + " Fall'>";
-    date_list_InnerHTML += "<option value='" + yearRange + " Spring'>";
-    date_list_InnerHTML += "<option value='" + yearRange + " Summer'>";
+    // Only allow Fall term for 2025-2026 academic year
+    if (i === 2025) {
+        date_list_InnerHTML += "<option value='" + yearRange + " Fall'>";
+        terms.push(yearRange + " Fall");
+    } else {
+        date_list_InnerHTML += "<option value='" + yearRange + " Fall'>";
+        date_list_InnerHTML += "<option value='" + yearRange + " Spring'>";
+        date_list_InnerHTML += "<option value='" + yearRange + " Summer'>";
 
-    // Add to terms array in chronological order: Fall, Spring, Summer
-    terms.push(yearRange + " Fall");
-    terms.push(yearRange + " Spring");
-    terms.push(yearRange + " Summer");
+        terms.push(yearRange + " Fall");
+        terms.push(yearRange + " Spring");
+        terms.push(yearRange + " Summer");
+    }
 }
 
 // Utility: convert a term name like "2023-2024 Fall" to its numeric code

--- a/main.js
+++ b/main.js
@@ -117,6 +117,9 @@ function SUrriculum(major_chosen_by_user) {
 
     fetchCourseData(major_chosen_by_user, entryTermCode)
     .then(async json => {
+        if (!json || json.length === 0) {
+            alert('No course data available for ' + major_chosen_by_user + ' in ' + entryTermName + '.');
+        }
     //START OF PROGRAM
         let change_major_element = document.querySelector('.change_major');
         let etElem = document.querySelector('.entryTerm');
@@ -1207,6 +1210,9 @@ function SUrriculum(major_chosen_by_user) {
             // recalcEffectiveTypes() can trigger DM recalculation automatically.
             // Fetch course data for second major
             fetchCourseData(dm, entryTermDMCode).then(function(jsonDM) {
+                if (!jsonDM || jsonDM.length === 0) {
+                    alert('No course data available for ' + dm + ' in ' + termCodeToName(entryTermDMCode));
+                }
                 doubleMajorCourseData = jsonDM || [];
                 // Save DM course data on the curriculum instance so
                 // recalcEffectiveTypes() can trigger DM recalculation.

--- a/update_credits.py
+++ b/update_credits.py
@@ -85,12 +85,39 @@ def update_json_with_credits(json_path, credits_map):
         print(f"Error updating {json_path}: {e}")
 
 def update_all_program_files(credits_map, program_files):
+    """Update all program JSON files with Basic Science and Engineering credits.
+
+    The courses directory may contain subfolders for each academic term
+    (e.g. ``202401``). This function walks through each term folder as well as
+    the root and reports any files that could not be updated.
     """
-    Update all program JSON files with Basic Science and Engineering credits.
-    """
-    for program_file in program_files.values():
-        program_file_path = os.path.join(COURSES_DIR, program_file)
-        update_json_with_credits(program_file_path, credits_map)
+
+    term_dirs = ['.']
+    term_dirs += [d for d in os.listdir(COURSES_DIR) if re.match(r'\d{6}$', d)]
+
+    failed_terms = []
+
+    for term in term_dirs:
+        term_path = os.path.join(COURSES_DIR, term) if term != '.' else COURSES_DIR
+        term_ok = True
+        for program_file in program_files.values():
+            program_file_path = os.path.join(term_path, program_file)
+            if os.path.exists(program_file_path):
+                try:
+                    update_json_with_credits(program_file_path, credits_map)
+                except Exception as e:
+                    print(f"Failed updating {program_file_path}: {e}")
+                    term_ok = False
+            else:
+                print(f"Missing {program_file_path}")
+                term_ok = False
+        if not term_ok:
+            failed_terms.append(term)
+
+    if failed_terms:
+        print('Failed updates for terms: ' + ', '.join(failed_terms))
+    else:
+        print('All term updates completed successfully.')
 
 if __name__ == "__main__":
     csv_path = "Pre-Conversion Files/katalog_basic_eng_degerler_202401_yuklenen_07.05.2025 (1)-converted.csv"


### PR DESCRIPTION
## Summary
- enhance `fetch_requirements.py` to read local HTML files and parse the summary table
- limit term generation to Fall 2025 and report failures in fetch scripts
- update `update_credits.py` to show missing file info per term
- restrict selectable terms in `helper_functions.js`
- warn in the UI if course data for a selected term is missing

## Testing
- `python fetch_requirements.py`
- `python update_credits.py`
- `python fetch_courses.py` *(terminated: network request stalled)*

------
https://chatgpt.com/codex/tasks/task_e_688a22abc910832aaf76f55169a89807