### PR TITLE
Load requirements from JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Course catalogs for each program are stored as JSON files under `courses/`. To r
 
 1. Edit `fetch_courses.py` if the university site changes and run `python fetch_courses.py` to regenerate the JSON files. The scraper now downloads data for every term starting from Fall 2019 and stores them under `courses/<TERM>/`. A `terms.json` file indicates which majors are available for each term.
 2. Use `update_credits.py` when Basic Science and Engineering credit values need to be extracted from official CSV/HTML sources.
-3. Modify `requirements.js` for new or changed graduation rules and update matching messages in `main.js`.
+3. Update the JSON files under `requirements/` for new or changed graduation rules and update matching messages in `main.js`.
 
 When using the planner, select your major and specify the entry term for both your main major and optional double major. Course lists and graduation requirements adjust automatically based on the selected terms.
 

--- a/requirements.js
+++ b/requirements.js
@@ -1,8 +1,7 @@
 // requirements.js
 // Degree requirements are stored as JSON files under `requirements/<TERM>.json`.
 // This module loads the file matching the user's selected entry term. If no
-// term-specific file is found, it falls back to `requirements/default.json` and
-// finally the hard-coded values below.
+// term-specific file is found, it falls back to `requirements/default.json`.
 
 let requirements = {};
 
@@ -19,154 +18,15 @@ function loadRequirements(termCode) {
     } catch (_) {}
     return null;
   };
-  return tryLoad(path) || tryLoad(defPath) || null;
-}
-
-const fallbackRequirements = {
-  // ----- Engineering majors -----
-  CS: {
-    total: 125,
-    ects: 240,
-    university: 41,
-    required: 29,
-    core: 31,
-    area: 9,
-    free: 15,
-    science: 60,
-    engineering: 90,
-    internshipCourse: 'CS395'
-  },
-  IE: {
-    total: 125,
-    ects: 240,
-    university: 41,
-    required: 34,
-    core: 26,
-    area: 9,
-    free: 15,
-    science: 60,
-    engineering: 90,
-    internshipCourse: 'IE395'
-  },
-  EE: {
-    total: 125,
-    ects: 240,
-    university: 41,
-    required: 35,
-    core: 25,
-    area: 9,
-    free: 15,
-    science: 60,
-    engineering: 90,
-    internshipCourse: 'EE395'
-  },
-  BIO: {
-    total: 127,
-    ects: 240,
-    university: 41,
-    required: 33,
-    core: 29,
-    area: 9,
-    free: 15,
-    science: 60,
-    engineering: 90,
-    internshipCourse: 'BIO395'
-  },
-  ME: {
-    total: 125,
-    ects: 240,
-    university: 41,
-    required: 34,
-    core: 26,
-    area: 9,
-    free: 15,
-    science: 60,
-    engineering: 90,
-    internshipCourse: 'ME395'
-  },
-  MAT: {
-    total: 125,
-    ects: 240,
-    university: 41,
-    required: 34,
-    core: 26,
-    area: 9,
-    free: 15,
-    science: 60,
-    engineering: 90,
-    internshipCourse: 'MAT395'
-  },
-  DSA: {
-    total: 125,
-    ects: 240,
-    university: 41,
-    required: 30,
-    core: 27,
-    area: 12,
-    free: 15,
-    science: 0,
-    engineering: 0,
-    internshipCourse: 'DSA395'
-  },
-
-  // ----- FASS majors with the 44 SU university rule -----
-  ECON: {
-    total: 125,
-    ects: 240,
-    university: 44,
-    required: 21,
-    core: 12,
-    area: 18,
-    free: 30,
-    science: 0,
-    engineering: 0
-  },
-  MAN: {
-    total: 127,
-    ects: 240,
-    university: 44,
-    required: 15,
-    core: 18,
-    area: 24,
-    free: 26,
-    science: 0,
-    engineering: 0
-  },
-  PSIR: {
-    total: 125,
-    ects: 240,
-    university: 44,
-    required: 24,
-    core: 24,
-    area: 15,
-    free: 18,
-    science: 0,
-    engineering: 0
-  },
-  PSY: {
-    total: 125,
-    ects: 240,
-    university: 44,
-    required: 21,
-    core: 21,
-    area: 18,
-    free: 21,
-    science: 0,
-    engineering: 0,
-    internshipCourse: 'PSY300'
-  },
-  VACD: {
-    total: 125,
-    ects: 240,
-    university: 44,
-    required: 15,
-    core: 21,
-    area: 24,
-    free: 21,
-    science: 0,
-    engineering: 0
+  let data = tryLoad(path) || tryLoad(defPath) || null;
+  if (data) {
+    for (const maj of Object.keys(data)) {
+      if (data[maj].science === undefined) data[maj].science = 0;
+      if (data[maj].engineering === undefined) data[maj].engineering = 0;
+    }
   }
-};
+  return data;
+}
 
 let termName = '';
 try {
@@ -176,8 +36,8 @@ let termCode = '';
 try {
   if (typeof termNameToCode === 'function') termCode = termNameToCode(termName);
 } catch (_) {}
-const loadedReq = termCode ? loadRequirements(termCode) : null;
-export const requirements = loadedReq || fallbackRequirements;
+const loadedReq = loadRequirements(termCode || 'default') || {};
+export const requirements = loadedReq;
 
 // Expose the requirements object on the window in browser environments. This
 // allows other scripts to access `requirements` when modules are not


### PR DESCRIPTION
## Summary
- remove in-code fallback requirements
- load requirement files directly from `requirements/`
- default missing science/engineering to 0
- update docs about editing requirements

## Testing
- `node --check requirements.js`
- `python -m py_compile update_credits.py fetch_requirements.py`


------
https://chatgpt.com/codex/tasks/task_e_688b2273bfa8832aa77a8125ab9ed661