### PR TITLE
Fix flag code mapping for graduation checks

### DIFF
--- a/flagMessages.js
+++ b/flagMessages.js
@@ -5,7 +5,14 @@
 // function will be attached to the global window for other scripts to call.
 
 export function buildFlagMessages(major) {
-  const req = requirements[major];
+  // Retrieve the requirements object from the global scope when running in
+  // the browser. This avoids reference errors when this module is parsed by
+  // Node or other environments where "requirements" isn't a top-level
+  // variable.
+  const allReq = (typeof globalThis !== 'undefined' && globalThis.requirements)
+    ? globalThis.requirements
+    : {};
+  const req = allReq[major] || {};
 
   return {
       1: () => `Your University SU credit is less than ${req.university}.`,

--- a/graduation_check.js
+++ b/graduation_check.js
@@ -105,7 +105,13 @@ function displaySummary(curriculum, major_chosen_by_user) {
     }
     const gpaMain = gpaCredits ? (gpaValue / gpaCredits).toFixed(3) : '0.000';
     // Determine limits from requirements for primary major
-    const reqMain = requirements[major_chosen_by_user] || {};
+    // Access the requirements object via the global scope to avoid reference
+    // errors when this script runs in environments without an imported
+    // variable.
+    const allReq = (typeof globalThis !== 'undefined' && globalThis.requirements)
+        ? globalThis.requirements
+        : {};
+    const reqMain = allReq[major_chosen_by_user] || {};
     const limitsMain = [
         '4.0',
         String(reqMain.total || 0),
@@ -151,7 +157,7 @@ function displaySummary(curriculum, major_chosen_by_user) {
         }
         const gpaDM = gpaCreditsDM ? (gpaValueDM / gpaCreditsDM).toFixed(3) : '0.000';
         // Determine limits for DM (SU +30, ECTS +60)
-        const dmReq = requirements[curriculum.doubleMajor] || {};
+        const dmReq = allReq[curriculum.doubleMajor] || {};
         const limitsDM = [
             '4.0',
             String((dmReq.total || 0) + 30),

--- a/s_curriculum.js
+++ b/s_curriculum.js
@@ -128,9 +128,11 @@ function s_curriculum()
         // Check core, area and free credits against requirements directly.
         // Do not perform dynamic reallocation here because the effective
         // categories have already been computed via recalcEffectiveTypes().
-        if (core < req.core) return 6;
-        if (area < req.area) return 7;
-        if (free < req.free) return 8;
+        // Flag codes must align with flagMessages.js:
+        // 3=core, 6=area, 7=free, 8=science.
+        if (core < req.core) return 3;
+        if (area < req.area) return 6;
+        if (free < req.free) return 7;
         // GPA check for graduation
         const gpaThresholdMainMajor = 2.00;
         let GPA = gpaCredits ? (gpaValue / gpaCredits).toFixed(3) : NaN;
@@ -1302,10 +1304,11 @@ function s_curriculum()
         if (engineering < (req.engineering || 0)) return 9;
         if (ects < ectsReq) return 10;
         if (required < (req.required || 0)) return 2;
-        // Core/area/free requirements
-        if (core < (req.core || 0)) return 6;
-        if (area < (req.area || 0)) return 7;
-        if (free < (req.free || 0)) return 8;
+        // Core/area/free requirements. Flag codes mirror flagMessages.js
+        // where 3=core, 6=area, 7=free and 8=science.
+        if (core < (req.core || 0)) return 3;
+        if (area < (req.area || 0)) return 6;
+        if (free < (req.free || 0)) return 7;
         // GPA check for graduation
         const gpaThresholdDoubleMajor = 3.20;
         let GPA = gpaCreditsDM ? (gpaValueDM / gpaCreditsDM).toFixed(3) : NaN;


### PR DESCRIPTION
## Summary
- correct mismatched flag codes in graduation logic
- ensure area and free elective requirements return the proper flags
- reference `requirements` via global object in modules to avoid runtime errors

## Testing
- `node --check flagMessages.js s_curriculum.js main.js graduation_check.js`


------
https://chatgpt.com/codex/tasks/task_e_688b306108d0832abe728ef3b93b0de6