### PR TITLE
Fix double major requirements year lookup

### DIFF
--- a/flagMessages.js
+++ b/flagMessages.js
@@ -12,7 +12,26 @@ export function buildFlagMessages(major) {
   const allReq = (typeof globalThis !== 'undefined' && globalThis.requirements)
     ? globalThis.requirements
     : {};
-  const req = allReq[major] || {};
+  let req = allReq[major];
+  if (!req) {
+    // When requirements are organized by term code, determine the correct
+    // term using the global curriculum object.
+    const curr = (typeof globalThis !== 'undefined' && globalThis.curriculum)
+      ? globalThis.curriculum
+      : {};
+    let term = '';
+    if (curr.major === major) term = curr.entryTerm;
+    else if (curr.doubleMajor === major) term = curr.entryTermDM;
+    if (term && allReq[term] && allReq[term][major]) {
+      req = allReq[term][major];
+    } else {
+      // Fallback: search all term groups
+      for (const t of Object.keys(allReq)) {
+        if (allReq[t] && allReq[t][major]) { req = allReq[t][major]; break; }
+      }
+    }
+  }
+  req = req || {};
 
   return {
       1: () => `Your University SU credit is less than ${req.university}.`,

--- a/graduation_check.js
+++ b/graduation_check.js
@@ -111,7 +111,17 @@ function displaySummary(curriculum, major_chosen_by_user) {
     const allReq = (typeof globalThis !== 'undefined' && globalThis.requirements)
         ? globalThis.requirements
         : {};
-    const reqMain = allReq[major_chosen_by_user] || {};
+
+    function lookupReq(major, term) {
+        if (allReq[major]) return allReq[major];
+        if (term && allReq[term] && allReq[term][major]) return allReq[term][major];
+        for (const t of Object.keys(allReq)) {
+            if (allReq[t] && allReq[t][major]) return allReq[t][major];
+        }
+        return {};
+    }
+
+    const reqMain = lookupReq(major_chosen_by_user, curriculum.entryTerm);
     const limitsMain = [
         '4.0',
         String(reqMain.total || 0),
@@ -157,7 +167,7 @@ function displaySummary(curriculum, major_chosen_by_user) {
         }
         const gpaDM = gpaCreditsDM ? (gpaValueDM / gpaCreditsDM).toFixed(3) : '0.000';
         // Determine limits for DM (SU +30, ECTS +60)
-        const dmReq = allReq[curriculum.doubleMajor] || {};
+        const dmReq = lookupReq(curriculum.doubleMajor, curriculum.entryTermDM);
         const limitsDM = [
             '4.0',
             String((dmReq.total || 0) + 30),

--- a/requirements.js
+++ b/requirements.js
@@ -29,15 +29,30 @@ function loadRequirements(termCode) {
 }
 
 let termName = '';
+let termNameDM = '';
 try {
   termName = localStorage.getItem('entryTerm') || '';
+  termNameDM = localStorage.getItem('entryTermDM') || termName;
 } catch (_) {}
+
 let termCode = '';
+let termCodeDM = '';
 try {
-  if (typeof termNameToCode === 'function') termCode = termNameToCode(termName);
+  if (typeof termNameToCode === 'function') {
+    termCode = termNameToCode(termName);
+    termCodeDM = termNameToCode(termNameDM);
+  }
 } catch (_) {}
-const loadedReq = loadRequirements(termCode || 'default') || {};
-requirements = loadedReq;
+
+const loadedMain = loadRequirements(termCode || 'default') || {};
+let loadedDM = null;
+if (termCodeDM && termCodeDM !== termCode) {
+  loadedDM = loadRequirements(termCodeDM);
+}
+
+requirements = loadedDM
+  ? { [termCode || 'default']: loadedMain, [termCodeDM]: loadedDM }
+  : loadedMain;
 export { requirements, loadRequirements };
 
 // Expose the requirements object on the window in browser environments. This


### PR DESCRIPTION
## Summary
- load requirements for both main and double majors
- fetch correct requirement set for flag messages
- update summary calculation to use term-based requirements

## Testing
- `node --check requirements.js`
- `node --check flagMessages.js`
- `node --check graduation_check.js`


------
https://chatgpt.com/codex/tasks/task_e_688b4718fc04832a8312b4b7947d811c