### PR TITLE
Move entry-term buttons next to major buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,14 +62,18 @@
                 <div class="head_btn_end"> <p>+</p> </div>
             </div>
             <div class="btns">
-                <button class="change_major btn"> <p>...</p> </button>
+                <div class="major-row">
+                    <button class="change_major btn"><p>...</p></button>
+                    <button class="entryTerm btn"><p>Entry Term</p></button>
+                </div>
                 <!-- Double Major button: behaves like major selection.  The
                      current double major (or None) is displayed as text.  When
                      clicked it becomes an input allowing the user to choose
                      another major or select none.  -->
-                <button class="doubleMajor btn"><p>Double Major: None</p></button>
-                <button class="entryTerm btn"><p>Entry Term</p></button>
-                <button class="entryTermDM btn"><p>DM Term</p></button>
+                <div class="major-row">
+                    <button class="doubleMajor btn"><p>Double Major: None</p></button>
+                    <button class="entryTermDM btn"><p>DM Term</p></button>
+                </div>
                 <button class="addSemester btn"> <p>New Semester</p> </button>
                 <button class="check btn"><p>Check Graduation</p></button>
                 <button class="summary btn"><p class="summary_p">Summary</p></button>

--- a/styles.css
+++ b/styles.css
@@ -597,6 +597,21 @@ input
     align-items: center;
 }
 
+.major-row {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    width: 100%;
+    margin-bottom: 20px;
+}
+.major-row .btn {
+    width: 140px;
+    margin-bottom: 0;
+}
+.major-row .change_major > input {
+    width: 140px;
+}
+
 .btn
 {
     margin-bottom: 20px;


### PR DESCRIPTION
## Summary
- move entry-term buttons beside major selection controls
- add new CSS for horizontal layout of major and entry term buttons

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688b4f5a1b08832aabee8e6d4457ee7e