### PR TITLE
Align term UI with main major style

### DIFF
--- a/academic_records_parser.js
+++ b/academic_records_parser.js
@@ -154,10 +154,10 @@ function importParsedCourses(parsedCourses, courseData, curriculum) {
         // Extract the semester pattern like "Fall 2022-2023" from the header
         let match = semester.match(/(Fall|Spring|Summer)\s+(\d{4}-\d{4})/);
         if (match) {
-            // Reformat it to the expected format: "2022-2023 Fall"
+            // Reformat it to the expected format: "Fall 2022-2023"
             const term = match[1];
             const yearRange = match[2];
-            return yearRange + " " + term;
+            return term + " " + yearRange;
         }
         return semester;
     };

--- a/create_semester.js
+++ b/create_semester.js
@@ -48,25 +48,27 @@ function createSemeter(aslastelement=true, courseList=[], curriculum, course_dat
         // Get all existing semesters to determine the next logical one
         const existingSemesters = document.querySelectorAll('.date p');
         if (existingSemesters.length > 0) {
-            // Find the latest semester
-            let latestSemester = '';
+            // Determine the chronologically latest semester using the
+            // ordering of the global `terms` array (latest term has the
+            // smallest index).
+            let latestIdx = terms.length;
             existingSemesters.forEach(semElem => {
                 const semText = semElem.textContent;
-                if (semText > latestSemester) {
-                    latestSemester = semText;
+                const idx = terms.indexOf(semText);
+                if (idx !== -1 && idx < latestIdx) {
+                    latestIdx = idx;
                 }
             });
 
-            // Find this semester in the terms array
-            const currentIndex = terms.indexOf(latestSemester);
+            const currentIndex = latestIdx;
 
-            if (currentIndex !== -1) {
-                // Determine the next logical term index
-                // By default, we'll use the next non-summer term in sequence
+            if (currentIndex !== terms.length) {
+                // Determine the next logical term index in descending list
                 for (let i = 1; i < terms.length; i++) {
-                    const nextCandidate = terms[(currentIndex + i) % terms.length];
+                    const idx = (currentIndex - i + terms.length) % terms.length;
+                    const nextCandidate = terms[idx];
                     if (!nextCandidate.includes("Summer")) {
-                        nextTermIndex = (currentIndex + i) % terms.length;
+                        nextTermIndex = idx;
                         break;
                     }
                 }
@@ -79,13 +81,13 @@ function createSemeter(aslastelement=true, courseList=[], curriculum, course_dat
 
                 if (currentMonth >= 7) { // August-December: Fall semester
                     const currentYear = currentDate.getFullYear();
-                    termToUse = currentYear + "-" + (currentYear + 1) + " Fall";
+                    termToUse = 'Fall ' + currentYear + '-' + (currentYear + 1);
                 } else if (currentMonth >= 0 && currentMonth < 5) { // January-May: Spring semester
                     const currentYear = currentDate.getFullYear();
-                    termToUse = (currentYear - 1) + "-" + currentYear + " Spring";
+                    termToUse = 'Spring ' + (currentYear - 1) + '-' + currentYear;
                 } else { // June-July: Summer
                     const currentYear = currentDate.getFullYear();
-                    termToUse = (currentYear - 1) + "-" + currentYear + " Summer";
+                    termToUse = 'Summer ' + (currentYear - 1) + '-' + currentYear;
                 }
 
                 nextTermIndex = terms.indexOf(termToUse) !== -1 ? terms.indexOf(termToUse) : 0;

--- a/helper_functions.js
+++ b/helper_functions.js
@@ -83,45 +83,45 @@ if (currentMonth >= 7) { // August or later
 // than 2019 so that the earliest selectable term matches the scraped data.
 const startYear = Math.max(2019, academicYear - 6);
 const endYear = Math.min(2025, academicYear + 6);
-for (let i = startYear; i <= endYear; i++) {
+for (let i = endYear; i >= startYear; i--) {
     // Create academic year string (e.g., "2022-2023")
     let yearRange = i + "-" + (i + 1);
 
     // Only allow Fall term for 2025-2026 academic year
     if (i === 2025) {
-        date_list_InnerHTML += "<option value='" + yearRange + " Fall'>";
-        terms.push(yearRange + " Fall");
+        date_list_InnerHTML += "<option value='Fall " + yearRange + "'>";
+        terms.push("Fall " + yearRange);
     } else {
-        date_list_InnerHTML += "<option value='" + yearRange + " Fall'>";
-        date_list_InnerHTML += "<option value='" + yearRange + " Spring'>";
-        date_list_InnerHTML += "<option value='" + yearRange + " Summer'>";
+        date_list_InnerHTML += "<option value='Summer " + yearRange + "'>";
+        date_list_InnerHTML += "<option value='Spring " + yearRange + "'>";
+        date_list_InnerHTML += "<option value='Fall " + yearRange + "'>";
 
-        terms.push(yearRange + " Fall");
-        terms.push(yearRange + " Spring");
-        terms.push(yearRange + " Summer");
+        terms.push("Summer " + yearRange);
+        terms.push("Spring " + yearRange);
+        terms.push("Fall " + yearRange);
     }
 }
 
-// Utility: convert a term name like "2023-2024 Fall" to its numeric code
+// Utility: convert a term name like "Fall 2023-2024" to its numeric code
 // (e.g. "202301"). This is used to map user selections to the folders
 // produced by the scraper.
 function termNameToCode(name) {
-    const m = name && name.match(/(\d{4})-\d{4} (Fall|Spring|Summer)/);
+    const m = name && name.match(/(Fall|Spring|Summer)\s+(\d{4})-(\d{4})/);
     if (!m) return '';
-    const year = m[1];
-    const suffix = { 'Fall': '01', 'Spring': '02', 'Summer': '03' }[m[2]] || '01';
+    const year = m[2];
+    const suffix = { 'Fall': '01', 'Spring': '02', 'Summer': '03' }[m[1]] || '01';
     return year + suffix;
 }
 
 // Reverse of termNameToCode. Converts numeric term code to display string
-// like "2023-2024 Fall".
+// like "Fall 2023-2024".
 function termCodeToName(code) {
     if (!code || code.length !== 6) return '';
     const year = code.slice(0, 4);
     const termNum = code.slice(4);
     const term = { '01': 'Fall', '02': 'Spring', '03': 'Summer' }[termNum] || '';
     const nextYear = String(parseInt(year, 10) + 1);
-    return year + '-' + nextYear + ' ' + term;
+    return term + ' ' + year + '-' + nextYear;
 }
 
 var grade_list_InnerHTML = '';

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
             <div class="btns">
                 <div class="major-row">
                     <button class="change_major btn"><p>...</p></button>
-                    <button class="entryTerm btn"><p>Entry Term</p></button>
+                    <button class="entryTerm btn"><p>Admit Term</p></button>
                 </div>
                 <!-- Double Major button: behaves like major selection.  The
                      current double major (or None) is displayed as text.  When
@@ -72,7 +72,7 @@
                      another major or select none.  -->
                 <div class="major-row">
                     <button class="doubleMajor btn"><p>Double Major: None</p></button>
-                    <button class="entryTermDM btn"><p>DM Term</p></button>
+                    <button class="entryTermDM btn"><p>Admit Term(DM)</p></button>
                 </div>
                 <button class="addSemester btn"> <p>New Semester</p> </button>
                 <button class="check btn"><p>Check Graduation</p></button>

--- a/main.js
+++ b/main.js
@@ -104,9 +104,9 @@ function SUrriculum(major_chosen_by_user) {
             });
     }
     // Determine entry terms for main and double majors from localStorage. The
-    // terms are stored as display strings (e.g. "2023-2024 Fall"). We convert
+    // terms are stored as display strings (e.g. "Fall 2023-2024"). We convert
     // them to numeric codes to locate the scraped JSON files.
-    const entryTermName = localStorage.getItem('entryTerm') || terms[terms.length - 1];
+    const entryTermName = localStorage.getItem('entryTerm') || terms[0];
     const entryTermDMName = localStorage.getItem('entryTermDM') || entryTermName;
     const entryTermCode = termNameToCode(entryTermName);
     const entryTermDMCode = termNameToCode(entryTermDMName);
@@ -125,8 +125,8 @@ function SUrriculum(major_chosen_by_user) {
         let etElem = document.querySelector('.entryTerm');
         let etDmElem = document.querySelector('.entryTermDM');
     change_major_element.innerHTML = '<p>Major: ' + major_chosen_by_user + '</p>';
-        if (etElem) etElem.innerHTML = '<p>' + entryTermName + '</p>';
-        if (etDmElem) etDmElem.innerHTML = '<p>' + entryTermDMName + '</p>';
+        if (etElem) etElem.innerHTML = '<p>Admit Term: ' + entryTermName + '</p>';
+        if (etDmElem) etDmElem.innerHTML = '<p>Admit Term(DM): ' + entryTermDMName + '</p>';
 
     // ------------------------------------------------------------------
     // Build a double major selector below the primary major display.  This
@@ -327,12 +327,12 @@ function SUrriculum(major_chosen_by_user) {
         try {
             if (entry_term_el && !(e.target.classList.contains('entryTerm') || (e.target.parentNode && e.target.parentNode.classList.contains('entryTerm')))) {
                 if (!entry_term_el.querySelector('input')) {
-                    entry_term_el.innerHTML = '<p>' + entryTermName + '</p>';
+                    entry_term_el.innerHTML = '<p>Admit Term: ' + entryTermName + '</p>';
                 }
             }
             if (entry_term_dm_el && !(e.target.classList.contains('entryTermDM') || (e.target.parentNode && e.target.parentNode.classList.contains('entryTermDM')))) {
                 if (!entry_term_dm_el.querySelector('input')) {
-                    entry_term_dm_el.innerHTML = '<p>' + entryTermDMName + '</p>';
+                    entry_term_dm_el.innerHTML = '<p>Admit Term(DM): ' + entryTermDMName + '</p>';
                 }
             }
         } catch (_) {}
@@ -476,7 +476,7 @@ function SUrriculum(major_chosen_by_user) {
                             localStorage.setItem('entryTerm', ev.target.value);
                             location.reload();
                         } else {
-                            entry_term_el.innerHTML = `<p>${entryTermName}</p>`;
+                            entry_term_el.innerHTML = `<p>Admit Term: ${entryTermName}</p>`;
                         }
                     });
                 }
@@ -504,7 +504,7 @@ function SUrriculum(major_chosen_by_user) {
                             localStorage.setItem('entryTermDM', ev.target.value);
                             location.reload();
                         } else {
-                            entry_term_dm_el.innerHTML = `<p>${entryTermDMName}</p>`;
+                            entry_term_dm_el.innerHTML = `<p>Admit Term(DM): ${entryTermDMName}</p>`;
                         }
                     });
                 }

--- a/styles.css
+++ b/styles.css
@@ -634,6 +634,15 @@ input
     background-color: #435A74;
 }
 
+.doubleMajor > input,
+.entryTerm > input,
+.entryTermDM > input {
+    width: 180px;
+    height: 100%;
+    background-color: #435A74;
+    color: white;
+}
+
 /* Style the double major selection to match the appearance of the main
    major control.  The select element inherits the button-like look
    used throughout the app (same width, colours and border radius). */


### PR DESCRIPTION
## Summary
- style entry term and double major inputs like major selector
- display entry terms with "Admit Term" labels
- list latest terms first and switch to `Fall YYYY-YYYY` term format
- update term parsing and semester creation logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b5438b4b0832a8333715a281f89d9