### PR TITLE
Fix entry term range

### DIFF
--- a/create_semester.js
+++ b/create_semester.js
@@ -93,6 +93,10 @@ function createSemeter(aslastelement=true, courseList=[], curriculum, course_dat
                 nextTermIndex = terms.indexOf(termToUse) !== -1 ? terms.indexOf(termToUse) : 0;
             }
         }
+        else {
+            // No semesters yet; start from the earliest available term
+            nextTermIndex = terms.length - 1;
+        }
 
         date.innerHTML = '<p>' + terms[nextTermIndex] + '</p>';
     }

--- a/helper_functions.js
+++ b/helper_functions.js
@@ -67,6 +67,8 @@ let currentMonth = currentDate.getMonth(); // 0-11, where 0 is January
 
 var date_list_InnerHTML = '';
 var terms = [];
+var entry_date_list_InnerHTML = '';
+var entryTerms = [];
 
 // Determine the current academic year
 let academicYear;
@@ -101,6 +103,27 @@ for (let i = endYear; i >= startYear; i--) {
         terms.push("Summer " + yearRange);
         terms.push("Spring " + yearRange);
         terms.push("Fall " + yearRange);
+    }
+}
+
+// Entry term options are limited to Fall 2025-2026. Build a
+// separate list so that admit term selectors are capped while
+// semester dates can extend further into the future.
+const entryEndYear = 2025;
+const entryStartYear = startYear;
+for (let i = entryEndYear; i >= entryStartYear; i--) {
+    const yearRange = i + '-' + (i + 1);
+    if (i === 2025) {
+        entry_date_list_InnerHTML += "<option value='Fall " + yearRange + "'>";
+        entryTerms.push('Fall ' + yearRange);
+    } else {
+        entry_date_list_InnerHTML += "<option value='Summer " + yearRange + "'>";
+        entry_date_list_InnerHTML += "<option value='Spring " + yearRange + "'>";
+        entry_date_list_InnerHTML += "<option value='Fall " + yearRange + "'>";
+
+        entryTerms.push('Summer ' + yearRange);
+        entryTerms.push('Spring ' + yearRange);
+        entryTerms.push('Fall ' + yearRange);
     }
 }
 

--- a/main.js
+++ b/main.js
@@ -106,7 +106,7 @@ function SUrriculum(major_chosen_by_user) {
     // Determine entry terms for main and double majors from localStorage. The
     // terms are stored as display strings (e.g. "Fall 2023-2024"). We convert
     // them to numeric codes to locate the scraped JSON files.
-    const entryTermName = localStorage.getItem('entryTerm') || terms[0];
+    const entryTermName = localStorage.getItem('entryTerm') || entryTerms[0];
     const entryTermDMName = localStorage.getItem('entryTermDM') || entryTermName;
     const entryTermCode = termNameToCode(entryTermName);
     const entryTermDMCode = termNameToCode(entryTermDMName);
@@ -469,10 +469,10 @@ function SUrriculum(major_chosen_by_user) {
                     inp.setAttribute('list','datalist_terms');
                     const dl = document.createElement('datalist');
                     dl.id = 'datalist_terms';
-                    terms.forEach(function(t){ dl.innerHTML += `<option value='${t}'>`; });
+                    entryTerms.forEach(function(t){ dl.innerHTML += `<option value='${t}'>`; });
                     entry_term_el.appendChild(inp); entry_term_el.appendChild(dl);
                     inp.addEventListener('input', function(ev){
-                        if (terms.indexOf(ev.target.value) !== -1) {
+                        if (entryTerms.indexOf(ev.target.value) !== -1) {
                             localStorage.setItem('entryTerm', ev.target.value);
                             location.reload();
                         } else {
@@ -497,10 +497,10 @@ function SUrriculum(major_chosen_by_user) {
                     inp.setAttribute('list','datalist_terms_dm');
                     const dl = document.createElement('datalist');
                     dl.id = 'datalist_terms_dm';
-                    terms.forEach(function(t){ dl.innerHTML += `<option value='${t}'>`; });
+                    entryTerms.forEach(function(t){ dl.innerHTML += `<option value='${t}'>`; });
                     entry_term_dm_el.appendChild(inp); entry_term_dm_el.appendChild(dl);
                     inp.addEventListener('input', function(ev){
-                        if (terms.indexOf(ev.target.value) !== -1) {
+                        if (entryTerms.indexOf(ev.target.value) !== -1) {
                             localStorage.setItem('entryTermDM', ev.target.value);
                             location.reload();
                         } else {


### PR DESCRIPTION
## Summary
- restrict admit term options to Fall 2025‑2026
- allow semester term selection up to 2030 and use earliest term when none exist
- update UI handlers to use the new admit term list

## Testing
- `node --check helper_functions.js`
- `node --check main.js`
- `node --check create_semester.js`


------
https://chatgpt.com/codex/tasks/task_e_688b8821cefc832a807378128355f848