### PR TITLE
Fix term selection defaults

### DIFF
--- a/create_semester.js
+++ b/create_semester.js
@@ -94,8 +94,15 @@ function createSemeter(aslastelement=true, courseList=[], curriculum, course_dat
             }
         }
         else {
-            // No semesters yet; start from the earliest available term
-            nextTermIndex = terms.length - 1;
+            // No semesters yet; start from the user's entry term if available
+            let entryTermName = '';
+            try {
+                entryTermName = localStorage.getItem('entryTerm') || entryTerms[0];
+            } catch (_) {
+                entryTermName = entryTerms[0];
+            }
+            const idx = terms.indexOf(entryTermName);
+            nextTermIndex = (idx !== -1) ? idx : terms.length - 1;
         }
 
         date.innerHTML = '<p>' + terms[nextTermIndex] + '</p>';

--- a/helper_functions.js
+++ b/helper_functions.js
@@ -91,19 +91,16 @@ for (let i = endYear; i >= startYear; i--) {
     // Create academic year string (e.g., "2022-2023")
     let yearRange = i + "-" + (i + 1);
 
-    // Only allow Fall term for 2025-2026 academic year
-    if (i === 2025) {
-        date_list_InnerHTML += "<option value='Fall " + yearRange + "'>";
-        terms.push("Fall " + yearRange);
-    } else {
-        date_list_InnerHTML += "<option value='Summer " + yearRange + "'>";
-        date_list_InnerHTML += "<option value='Spring " + yearRange + "'>";
-        date_list_InnerHTML += "<option value='Fall " + yearRange + "'>";
+    // Provide all three terms for each academic year. Previously the
+    // 2025-2026 year exposed only the Fall term which prevented users from
+    // selecting Spring 2025-2026.
+    date_list_InnerHTML += "<option value='Summer " + yearRange + "'>";
+    date_list_InnerHTML += "<option value='Spring " + yearRange + "'>";
+    date_list_InnerHTML += "<option value='Fall " + yearRange + "'>";
 
-        terms.push("Summer " + yearRange);
-        terms.push("Spring " + yearRange);
-        terms.push("Fall " + yearRange);
-    }
+    terms.push("Summer " + yearRange);
+    terms.push("Spring " + yearRange);
+    terms.push("Fall " + yearRange);
 }
 
 // Entry term options are limited to Fall 2025-2026. Build a
@@ -113,18 +110,17 @@ const entryEndYear = 2025;
 const entryStartYear = startYear;
 for (let i = entryEndYear; i >= entryStartYear; i--) {
     const yearRange = i + '-' + (i + 1);
-    if (i === 2025) {
-        entry_date_list_InnerHTML += "<option value='Fall " + yearRange + "'>";
-        entryTerms.push('Fall ' + yearRange);
-    } else {
-        entry_date_list_InnerHTML += "<option value='Summer " + yearRange + "'>";
-        entry_date_list_InnerHTML += "<option value='Spring " + yearRange + "'>";
-        entry_date_list_InnerHTML += "<option value='Fall " + yearRange + "'>";
 
-        entryTerms.push('Summer ' + yearRange);
-        entryTerms.push('Spring ' + yearRange);
-        entryTerms.push('Fall ' + yearRange);
-    }
+    // Allow admitting in any term of the academic year. Previously the most
+    // recent year only listed the Fall term which forced new plans to start
+    // from Fall 2025-2026 regardless of the user's actual admit term.
+    entry_date_list_InnerHTML += "<option value='Summer " + yearRange + "'>";
+    entry_date_list_InnerHTML += "<option value='Spring " + yearRange + "'>";
+    entry_date_list_InnerHTML += "<option value='Fall " + yearRange + "'>";
+
+    entryTerms.push('Summer ' + yearRange);
+    entryTerms.push('Spring ' + yearRange);
+    entryTerms.push('Fall ' + yearRange);
 }
 
 // Utility: convert a term name like "Fall 2023-2024" to its numeric code


### PR DESCRIPTION
## Summary
- allow Spring 2025-2026 to appear in term selectors
- allow any admit term in 2025-2026
- start the first semester from the user's entry term instead of 2019

## Testing
- `node - <<'EOF'
const fs=require('fs');
const vm=require('vm');
const code=fs.readFileSync('helper_functions.js','utf8');
vm.runInNewContext(code,{})
console.log('entry terms', entryTerms.length)
console.log('has Spring 2025-2026', entryTerms.includes('Spring 2025-2026'))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688b8e6b69ec832a84fb192e93eaadd1