### PR TITLE
Improve button layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,11 +75,15 @@
                     <button class="entryTermDM btn"><p>Admit Term(DM)</p></button>
                 </div>
                 <button class="addSemester btn"> <p>New Semester</p> </button>
-                <button class="check btn"><p>Check Graduation</p></button>
-                <button class="summary btn"><p class="summary_p">Summary</p></button>
-                <button class="autoAdd btn"> <p>Add First Year Courses</p></button>
-                <!-- Button to add a custom user-defined course -->
-                <button class="customCourse btn"><p>Add Custom Course</p></button>
+                <div class="major-row">
+                    <button class="check btn"><p>Check Graduation</p></button>
+                    <button class="summary btn"><p class="summary_p">Summary</p></button>
+                </div>
+                <div class="major-row">
+                    <button class="autoAdd btn"> <p>Add First Year Courses</p></button>
+                    <!-- Button to add a custom user-defined course -->
+                    <button class="customCourse btn"><p>Add Custom Course</p></button>
+                </div>
                 <!-- Button to delete all custom courses for the current major -->
                 <button class="deleteCustom btn"><p>Delete Custom Courses</p></button>
                 <!-- Button to reset all locally stored data (custom courses, saved semesters, etc.) -->

--- a/styles.css
+++ b/styles.css
@@ -632,7 +632,10 @@ input
     width: 140px;
     margin-bottom: 0;
 }
-.major-row .change_major > input {
+.major-row .change_major > input,
+.major-row .entryTerm > input,
+.major-row .doubleMajor > input,
+.major-row .entryTermDM > input {
     width: 140px;
 }
 


### PR DESCRIPTION
## Summary
- keep major/admit term button width consistent when selecting
- show Check Graduation/Summary and Add First Year Courses/Add Custom Course buttons side by side

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b918dae7c832aa13d2ae32350dc10