### PR TITLE
Fix reset button clearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Surriculum v2.0 (beta)
+# [Surriculum v2.3 (beta)](https://beficent.github.io/surriculum/)
 
 Surriculum is an interactive graduation planner for Sabanci University undergraduate programs. The entire application runs in the browser using plain HTML, CSS and JavaScript. It lets you build a semester-by-semester plan, track program requirements and check whether you are on course to graduate.
 
@@ -24,7 +24,7 @@ Course catalogs for each program are stored as JSON files under `courses/`. To r
 
 1. Edit `fetch_courses.py` if the university site changes and run `python fetch_courses.py` to regenerate the JSON files. The scraper now downloads data for every term starting from Fall 2019 and stores them under `courses/<TERM>/`. A `terms.json` file indicates which majors are available for each term.
 2. Use `update_credits.py` when Basic Science and Engineering credit values need to be extracted from official CSV/HTML sources.
-3. Update the JSON files under `requirements/` for new or changed graduation rules and update matching messages in `main.js`.
+3. Run `python fetch_requirements.py` to scrape updated graduation rules into the JSON files under `requirements/`. Update matching messages in `main.js` if necessary.
 
 When using the planner, select your major and specify the entry term for both your main major and optional double major. Course lists and graduation requirements adjust automatically based on the selected terms.
 

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@
 let course_data;
 //can only be CS, BIO, MAT, EE, ME, IE, ECON, DSA, MAN, PSIR, PSY, VACD:
 let initial_major_chosen = 'CS'
+let saveInterval;
 
 
 function SUrriculum(major_chosen_by_user) {
@@ -1001,8 +1002,8 @@ function SUrriculum(major_chosen_by_user) {
                     localStorage.removeItem('dates');
                     const customKey = 'customCourses_' + major_chosen_by_user;
                     localStorage.removeItem(customKey);
-                    localStorage.clear()
-                    localStorage.clear()
+                    clearInterval(saveInterval);
+                    localStorage.clear();
                 } catch (ex) {
                     console.error('Failed to clear localStorage:', ex);
                 }
@@ -1031,7 +1032,7 @@ function SUrriculum(major_chosen_by_user) {
         // ignore
     }
     //Save:
-    setInterval(function() {
+    saveInterval = setInterval(function() {
         localStorage.removeItem("curriculum");
         localStorage.setItem("curriculum", serializator(curriculum));
         localStorage.removeItem("grades");


### PR DESCRIPTION
## Summary
- make README title link to live site
- store interval ID and stop it on reset
- clear storage only once

## Testing
- `node --version`
- `python3 --version`


------
https://chatgpt.com/codex/tasks/task_e_688c64105fec832a86a1d8ac3956f866