### PR TITLE
Clean up curriculum manager usage

### DIFF
--- a/click.js
+++ b/click.js
@@ -123,7 +123,7 @@ function dynamic_click(e, curriculum, course_data)
 
         semObj.deleteCourse(courseElement.id);
         courseElement.remove();
-        CurriculumManager.updateSemesterTotalsDisplay(semesterElement.id, curriculum);
+        CurriculumManager.updateSemesterTotalsDisplay(semesterElement.id, curriculum, course_data);
     }
     //CLICKED "<semester_date_edit>"
     else if(e.target.classList.contains("semester_date_edit"))

--- a/create_semester.js
+++ b/create_semester.js
@@ -255,10 +255,10 @@ function createSemeter(aslastelement=true, courseList=[], curriculum, course_dat
         const courseCode = courseList[i];
         const courseId = CurriculumManager.addCourse(semester.id, courseCode, curriculum, course_data);
         if (courseId && grade_list.length && grade_list[i] && grade_list[i].length) {
-            CurriculumManager.updateCourseGrade(courseId, grade_list[i], curriculum);
+            CurriculumManager.updateCourseGrade(courseId, grade_list[i], curriculum, course_data);
         }
     }
 
     // Update semester totals display
-    CurriculumManager.updateSemesterTotalsDisplay(semester.id, curriculum);
+    CurriculumManager.updateSemesterTotalsDisplay(semester.id, curriculum, course_data);
 }

--- a/helper_functions.js
+++ b/helper_functions.js
@@ -305,37 +305,3 @@ function getAncestor(element, ancestor_class)
     return null;
 }
 
-// Function to update semester totals display with better formatting
-function updateSemesterTotalsDisplay(semesterId, curriculum) {
-    const semester = curriculum.getSemester(semesterId);
-    if (!semester) return;
-
-    const semesterElement = document.getElementById(semesterId);
-    if (!semesterElement) return;
-
-    const totalsElement = semesterElement.querySelector('.semester-totals');
-    if (!totalsElement) return;
-
-    // Calculate GPA for this semester
-    let semesterGPA = '0.00';
-    if (semester.totalGPACredits > 0) {
-        semesterGPA = (semester.totalGPA / semester.totalGPACredits).toFixed(2);
-    }
-
-    // Update each total value
-    const updates = [
-        { selector: '.total-totalcredit', value: semester.totalCredit },
-        { selector: '.total-totalgpa', value: semesterGPA },
-        { selector: '.total-totalcore', value: semester.totalCore },
-        { selector: '.total-totalarea', value: semester.totalArea },
-        { selector: '.total-totalfree', value: semester.totalFree },
-        { selector: '.total-totaluniversity', value: semester.totalUniversity }
-    ];
-
-    updates.forEach(update => {
-        const element = totalsElement.querySelector(update.selector);
-        if (element) {
-            element.textContent = update.value;
-        }
-    });
-}


### PR DESCRIPTION
## Summary
- Remove obsolete `updateSemesterTotalsDisplay` helper
- Use `CurriculumManager` utilities with required `course_data`

## Testing
- `npm test` (fails: Could not read package.json)
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_68909513ca64832aa344efbddfbe2021