### PR TITLE
Fix module export and DOM insertion for semester creation

### DIFF
--- a/create_semester.js
+++ b/create_semester.js
@@ -152,7 +152,6 @@ function createSemeter(aslastelement=true, courseList=[], curriculum, course_dat
         newsem.termIndex = null;
     }
 
-    const btn = document.querySelector(".addSemester");
     let addCourse = document.createElement("button");
     addCourse.classList.add("addCourse");
     addCourse.innerHTML = "+ Add another course";
@@ -162,11 +161,11 @@ function createSemeter(aslastelement=true, courseList=[], curriculum, course_dat
     subcontainer.appendChild(addCourse);
     container.appendChild(subcontainer);
     
-    if(aslastelement) 
+    if(aslastelement)
     {
-        board.insertBefore(container, btn.parentNode.parentNode);
+        board.appendChild(container);
     }
-    else 
+    else
     {
         board.insertBefore(container, board.firstChild);
     }

--- a/requirements.js
+++ b/requirements.js
@@ -53,7 +53,6 @@ if (termCodeDM && termCodeDM !== termCode) {
 requirements = loadedDM
   ? { [termCode || 'default']: loadedMain, [termCodeDM]: loadedDM }
   : loadedMain;
-export { requirements, loadRequirements };
 
 // Expose the requirements object on the window in browser environments. This
 // allows other scripts to access `requirements` when modules are not


### PR DESCRIPTION
## Summary
- Remove ES module export from `requirements.js` to prevent syntax error when loaded as a classic script
- Append new semester containers directly to the board to avoid `NotFoundError`

## Testing
- `node --check create_semester.js requirements.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68909e1b6004832a857682fd580976b4