### PR TITLE
Add ghost semester, centered modals, and theme detection

### DIFF
--- a/create_semester.js
+++ b/create_semester.js
@@ -263,4 +263,5 @@ function createSemeter(aslastelement=true, courseList=[], curriculum, course_dat
     } catch (err) {
         // Silent failure if curriculum or recalc is undefined
     }
+    return container;
 }

--- a/graduation_check.js
+++ b/graduation_check.js
@@ -6,15 +6,12 @@
 // Display graduation check results in a modal
 function displayGraduationResults(curriculum) {
     if(!document.querySelector('.graduation_modal')) {
-        const board_dom = document.querySelector(".board");
         const overlay = document.createElement("div");
         overlay.classList.add('graduation_modal_overlay');
         const modal = document.createElement("div");
         modal.classList.add('graduation_modal');
-        board_dom.appendChild(overlay);
-        board_dom.appendChild(modal);
-        const leftPosition = ((board_dom.offsetWidth) / 2) + board_dom.scrollLeft;
-        modal.style.left = leftPosition + 'px';
+        overlay.appendChild(modal);
+        document.body.appendChild(overlay);
         // Compose results for primary major
         let html = '';
         const flagMain = curriculum.canGraduate();
@@ -50,23 +47,18 @@ function displaySummary(curriculum, major_chosen_by_user) {
     if (document.querySelector('.summary_modal')) return;
     // Helper to build a summary modal for a given set of totals and limits.
     function buildSummaryModal(totals, limits, gpa, labelPrefix) {
-        const board_dom = document.querySelector(".board");
-        const modal = document.createElement("div");
-        modal.classList.add('summary_modal');
-        // Use the same overlay for both modals; create only if not present
+        // Overlay is shared by all summary modals. Create it on demand and
+        // append to the body so it covers the full viewport. The overlay uses
+        // flexbox centering so modals appear in the middle of the screen.
         let overlay = document.querySelector('.summary_modal_overlay');
         if (!overlay) {
             overlay = document.createElement('div');
             overlay.classList.add('summary_modal_overlay');
-            board_dom.appendChild(overlay);
+            document.body.appendChild(overlay);
         }
-        board_dom.appendChild(modal);
-        // Position relative to board scroll; first modal centered, second offset
-        const leftBase = ((board_dom.offsetWidth) / 2) + board_dom.scrollLeft;
-        // Determine how many modals already exist to offset accordingly
-        const index = document.querySelectorAll('.summary_modal').length - 1;
-        // Each additional modal is shifted right by 400px to avoid overlap
-        modal.style.left = (leftBase + index * 400) + 'px';
+        const modal = document.createElement('div');
+        modal.classList.add('summary_modal');
+        overlay.appendChild(modal);
         // Build content
         const labels = ['GPA: ', 'SU Credits: ', 'ECTS: ', 'University: ',  'Required: ', 'Core: ', 'Area: ', 'Free: ',  'Basic Science: ', 'Engineering: '];
         const total_values = [gpa, totals.total, totals.ects, totals.university, totals.required, totals.core, totals.area, totals.free, totals.science, totals.engineering];

--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
     <div class="main-content">
         <!-- Sidebar -->
         <aside class="sidebar">
+            <button class="sidebar-toggle">⮜</button>
             <div class="sidebar-header">
                 <h2 class="sidebar-title">📚 Controls</h2>
             </div>

--- a/main.js
+++ b/main.js
@@ -664,8 +664,47 @@ function SUrriculum(major_chosen_by_user) {
     //NON-DYNAMIC BUTTONS:
     const addSemester = document.querySelector(".addSemester");
     addSemester.addEventListener('click', function(){
-        createSemeter(true, [], curriculum, course_data)
+        const board = document.querySelector('.board');
+        const newContainer = createSemeter(true, [], curriculum, course_data);
+        const ghost = document.querySelector('.add-semester-ghost');
+        if (ghost && board) {
+            board.insertBefore(newContainer, ghost);
+            const style = getComputedStyle(newContainer);
+            const width = newContainer.offsetWidth + parseInt(style.marginLeft) + parseInt(style.marginRight);
+            board.scrollLeft += width;
+        }
     });
+
+    function ensureGhostSemester() {
+        const board = document.querySelector('.board');
+        if (!board) return;
+        let ghost = board.querySelector('.add-semester-ghost');
+        if (!ghost) {
+            ghost = document.createElement('div');
+            ghost.classList.add('add-semester-ghost');
+            ghost.textContent = '+ New Semester';
+            ghost.addEventListener('click', function() {
+                const newContainer = createSemeter(true, [], curriculum, course_data);
+                const style = getComputedStyle(newContainer);
+                const width = newContainer.offsetWidth + parseInt(style.marginLeft) + parseInt(style.marginRight);
+                board.insertBefore(newContainer, ghost);
+                board.scrollLeft += width;
+            });
+            board.appendChild(ghost);
+        }
+    }
+
+    // Create ghost container on initial load
+    ensureGhostSemester();
+
+    // Sidebar collapse toggle
+    const sidebar = document.querySelector('.sidebar');
+    const sidebarToggle = document.querySelector('.sidebar-toggle');
+    if (sidebar && sidebarToggle) {
+        sidebarToggle.addEventListener('click', function() {
+            sidebar.classList.toggle('collapsed');
+        });
+    }
 
     const auto_add = document.querySelector('.autoAdd');
     auto_add.addEventListener('click', function(){
@@ -734,66 +773,35 @@ function SUrriculum(major_chosen_by_user) {
             // Prevent multiple modals
             if (document.querySelector('.custom_course_modal')) return;
 
-        // Append the overlay to the document body rather than the board
-        // container so that it always covers the full viewport and is not
-        // clipped by the board's scroll container.  This also ensures the
-        // modal remains visible even if the board is scrolled horizontally.
+        // Append overlay to body so it covers the full viewport
         const boardDom = document.body;
 
-        // Create overlay with click-to-dismiss behaviour
+        // Create overlay container
         const overlay = document.createElement('div');
         overlay.classList.add('custom_course_overlay');
-        // Inline styling for overlay: darken background and capture clicks
-        overlay.style.position = 'fixed';
-        overlay.style.top = '0';
-        overlay.style.left = '0';
-        overlay.style.width = '100%';
-        overlay.style.height = '100%';
-        overlay.style.backgroundColor = 'rgba(0, 0, 0, 0.6)';
-        overlay.style.zIndex = '200';
-        overlay.style.display = 'flex';
-        overlay.style.justifyContent = 'center';
-        overlay.style.alignItems = 'center';
 
         // Create modal container
         const modal = document.createElement('div');
         modal.classList.add('custom_course_modal');
-        // Inline styling for modal: centre box with padding
-        modal.style.backgroundColor = '#f5f7fa';
-        modal.style.borderRadius = '6px';
-        modal.style.padding = '20px';
-        modal.style.minWidth = '300px';
-        modal.style.maxWidth = '500px';
-        modal.style.color = '#333';
-        modal.style.boxShadow = '0 3px 6px rgba(0,0,0,0.2)';
-        modal.style.zIndex = '201';
 
         // Title
         const title = document.createElement('h3');
         title.innerText = 'Add Custom Course';
-        title.style.marginTop = '0';
-        title.style.marginBottom = '15px';
         modal.appendChild(title);
 
         // Helper to create input row
         function createInputRow(labelText, inputType = 'text', placeholder = '', defaultValue = '') {
             const row = document.createElement('div');
-            row.style.display = 'flex';
-            row.style.flexDirection = 'column';
-            row.style.marginBottom = '10px';
+            row.classList.add('cc-row');
 
             const label = document.createElement('label');
             label.innerText = labelText;
-            label.style.marginBottom = '3px';
             row.appendChild(label);
 
             const input = document.createElement('input');
             input.type = inputType;
             input.placeholder = placeholder;
             input.value = defaultValue;
-            input.style.padding = '6px';
-            input.style.border = '1px solid #ccc';
-            input.style.borderRadius = '3px';
             row.appendChild(input);
 
             return { row, input };
@@ -827,12 +835,9 @@ function SUrriculum(major_chosen_by_user) {
 
             // EL Type dropdown
             const typeRow = document.createElement('div');
-            typeRow.style.display = 'flex';
-            typeRow.style.flexDirection = 'column';
-            typeRow.style.marginBottom = '10px';
+            typeRow.classList.add('cc-row');
             const typeLabel = document.createElement('label');
             typeLabel.innerText = 'Category (EL_Type):';
-            typeLabel.style.marginBottom = '3px';
             typeRow.appendChild(typeLabel);
             const typeSelect = document.createElement('select');
             ['core', 'area', 'university', 'free', 'required', 'none'].forEach(function(opt) {
@@ -841,9 +846,6 @@ function SUrriculum(major_chosen_by_user) {
                 option.innerText = opt.charAt(0).toUpperCase() + opt.slice(1);
                 typeSelect.appendChild(option);
             });
-            typeSelect.style.padding = '6px';
-            typeSelect.style.border = '1px solid #ccc';
-            typeSelect.style.borderRadius = '3px';
             typeRow.appendChild(typeSelect);
             modal.appendChild(typeRow);
 
@@ -893,18 +895,11 @@ function SUrriculum(major_chosen_by_user) {
 
         // Buttons container
         const buttonsRow = document.createElement('div');
-        buttonsRow.style.display = 'flex';
-        buttonsRow.style.justifyContent = 'flex-end';
-        buttonsRow.style.marginTop = '15px';
+        buttonsRow.classList.add('cc-buttons');
 
         const cancelBtn = document.createElement('button');
         cancelBtn.innerText = 'Cancel';
-        cancelBtn.style.marginRight = '10px';
-        cancelBtn.style.padding = '6px 12px';
-        cancelBtn.style.border = 'none';
-        cancelBtn.style.borderRadius = '3px';
-        cancelBtn.style.backgroundColor = '#ccc';
-        cancelBtn.style.cursor = 'pointer';
+        cancelBtn.classList.add('btn', 'btn-secondary', 'btn-sm');
             cancelBtn.addEventListener('click', function(e) {
                 e.stopPropagation();
                 overlay.remove();
@@ -917,12 +912,7 @@ function SUrriculum(major_chosen_by_user) {
 
         const saveBtn = document.createElement('button');
         saveBtn.innerText = 'Save';
-        saveBtn.style.padding = '6px 12px';
-        saveBtn.style.border = 'none';
-        saveBtn.style.borderRadius = '3px';
-        saveBtn.style.backgroundColor = '#4caf50';
-        saveBtn.style.color = 'white';
-        saveBtn.style.cursor = 'pointer';
+        saveBtn.classList.add('btn', 'btn-primary', 'btn-sm');
             saveBtn.addEventListener('click', function(e) {
                 e.stopPropagation();
                 // Read input values

--- a/styles.css
+++ b/styles.css
@@ -113,6 +113,7 @@ html, body {
     display: flex;
     overflow: hidden;
     min-height: 0; /* Important for flex children to shrink */
+    position: relative;
 }
 
 .board {
@@ -126,6 +127,8 @@ html, body {
     padding-left: 8px;
     padding-right: 8px;
     min-height: 0; /* Important for flex children to shrink */
+    margin-left: 320px;
+    transition: margin-left 0.3s ease;
 }
 
 /* === BUTTONS === */
@@ -188,6 +191,37 @@ html, body {
     flex-direction: column;
     overflow: hidden;
     flex-shrink: 0;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    transition: transform 0.3s ease;
+    z-index: 5;
+}
+
+.sidebar.collapsed {
+    transform: translateX(calc(-100% + 20px));
+}
+
+.sidebar-toggle {
+    position: absolute;
+    top: 8px;
+    right: -20px;
+    width: 20px;
+    height: 40px;
+    background: var(--primary);
+    color: var(--text-inverse);
+    border: none;
+    border-radius: 0 var(--radius-md) var(--radius-md) 0;
+    cursor: pointer;
+}
+
+.sidebar.collapsed .sidebar-toggle {
+    transform: rotate(180deg);
+}
+
+.sidebar.collapsed ~ .board {
+    margin-left: 20px;
 }
 
 .sidebar-header {
@@ -709,6 +743,25 @@ html, body {
     height: calc(100vh - 140px); /* Fixed height for proper scrolling */
 }
 
+/* Placeholder container for adding new semesters inline */
+.add-semester-ghost {
+    margin: 16px 8px;
+    flex: 0 0 320px;
+    border: 2px dashed var(--border);
+    border-radius: var(--radius-md);
+    height: calc(100vh - 140px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary);
+    cursor: pointer;
+    box-shadow: var(--shadow-sm);
+}
+
+.add-semester-ghost:hover {
+    background: var(--bg-surface);
+}
+
 /* Top bar showing total credits */
 .container_semester .total_credit {
     display: flex;
@@ -1092,13 +1145,15 @@ html, body {
     height: 100%;
     background: rgba(0, 0, 0, 0.4);
     z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 20px;
 }
 
 /* Graduation modal */
+
 .graduation_modal {
-    position: absolute;
-    top: 80px;
-    transform: translateX(-50%);
     width: 320px;
     background: var(--bg-card);
     border-radius: var(--radius-md);
@@ -1114,8 +1169,6 @@ html, body {
 
 /* Summary modal */
 .summary_modal {
-    position: absolute;
-    top: 80px;
     width: 340px;
     background: var(--bg-card);
     border: 1px solid var(--border);
@@ -1140,6 +1193,63 @@ html, body {
 
 .summary_modal_child:last-child {
     border-bottom: none;
+}
+
+.custom_course_overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 200;
+}
+
+.custom_course_modal {
+    background: var(--bg-card);
+    color: var(--text-primary);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
+    padding: 20px;
+    min-width: 300px;
+    max-width: 500px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.custom_course_modal h3 {
+    margin-top: 0;
+    margin-bottom: 15px;
+}
+
+.custom_course_modal label {
+    margin-bottom: 3px;
+}
+
+.custom_course_modal input,
+.custom_course_modal select {
+    padding: 6px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--bg-card);
+    color: var(--text-primary);
+}
+
+.custom_course_modal .cc-row {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 10px;
+}
+
+.custom_course_modal .cc-buttons {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 15px;
 }
 
 .semester-summary-wrapper {

--- a/theme.js
+++ b/theme.js
@@ -1,7 +1,14 @@
 // Theme management for SUrriculum
 document.addEventListener('DOMContentLoaded', function() {
-    // Get the current theme from localStorage or default to 'light-theme'
-    const currentTheme = localStorage.getItem('theme') || 'light-theme';
+    // Determine the theme to use. If the user has previously chosen a
+    // theme, use that. Otherwise detect the device preference and store
+    // it for subsequent loads so the choice persists across sessions.
+    let currentTheme = localStorage.getItem('theme');
+    if (!currentTheme) {
+        const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        currentTheme = prefersDark ? 'dark-theme' : 'light-theme';
+        localStorage.setItem('theme', currentTheme);
+    }
 
     // Apply the theme to the body
     document.body.className = currentTheme;


### PR DESCRIPTION
## Summary
- Center summary and graduation modals with flex overlays
- Style custom course modal to use app theme
- Add ghost semester placeholder and collapsible sidebar
- Detect system theme on first load and persist user choice

## Testing
- `node --check main.js`
- `node --check graduation_check.js`
- `node --check create_semester.js`
- `node --check theme.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891f6c0b2c4832aabffe61dde952693