### PR TITLE
Add sidebar toggle and style double major modal

### DIFF
--- a/main.js
+++ b/main.js
@@ -1258,33 +1258,15 @@ function SUrriculum(major_chosen_by_user) {
             if (document.querySelector('.double_major_modal')) return;
             const overlay = document.createElement('div');
             overlay.classList.add('double_major_overlay');
-            overlay.style.position = 'fixed';
-            overlay.style.top = '0';
-            overlay.style.left = '0';
-            overlay.style.width = '100%';
-            overlay.style.height = '100%';
-            overlay.style.backgroundColor = 'rgba(0,0,0,0.6)';
-            overlay.style.zIndex = '300';
-            overlay.style.display = 'flex';
-            overlay.style.justifyContent = 'center';
-            overlay.style.alignItems = 'center';
             const modal = document.createElement('div');
             modal.classList.add('double_major_modal');
-            modal.style.backgroundColor = '#f5f7fa';
-            modal.style.borderRadius = '6px';
-            modal.style.padding = '20px';
-            modal.style.minWidth = '250px';
-            modal.style.color = '#333';
-            modal.style.boxShadow = '0 3px 6px rgba(0,0,0,0.2)';
             // Title
             const h = document.createElement('h3');
             h.innerText = 'Set Category for Double Major';
-            h.style.marginTop = '0';
             modal.appendChild(h);
             // Info text
             const info = document.createElement('p');
             info.innerText = code + ' - ' + title;
-            info.style.marginBottom = '10px';
             modal.appendChild(info);
             // Select
             const select = document.createElement('select');
@@ -1294,22 +1276,13 @@ function SUrriculum(major_chosen_by_user) {
                 o.innerText = opt.charAt(0).toUpperCase() + opt.slice(1);
                 select.appendChild(o);
             });
-            select.style.padding = '6px';
-            select.style.border = '1px solid #ccc';
-            select.style.borderRadius = '3px';
-            select.style.marginBottom = '10px';
             modal.appendChild(select);
             // Buttons
             const buttons = document.createElement('div');
-            buttons.style.display = 'flex';
-            buttons.style.justifyContent = 'flex-end';
+            buttons.classList.add('dm-buttons');
             const save = document.createElement('button');
             save.innerText = 'Save';
-            save.style.backgroundColor = '#4caf50';
-            save.style.color = '#fff';
-            save.style.border = 'none';
-            save.style.padding = '6px 12px';
-            save.style.borderRadius = '3px';
+            save.classList.add('btn', 'btn-primary', 'btn-sm');
             save.onclick = function(e) {
                 e.stopPropagation();
                 const chosen = select.value;

--- a/styles.css
+++ b/styles.css
@@ -206,7 +206,7 @@ html, body {
 .sidebar-toggle {
     position: absolute;
     top: 8px;
-    right: -20px;
+    right: 0;
     width: 20px;
     height: 40px;
     background: var(--primary);
@@ -1246,6 +1246,54 @@ html, body {
 }
 
 .custom_course_modal .cc-buttons {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 15px;
+}
+
+/* Double Major Category Modal */
+.double_major_overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 200;
+}
+
+.double_major_modal {
+    background: var(--bg-card);
+    color: var(--text-primary);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
+    padding: 20px;
+    min-width: 250px;
+    max-width: 400px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.double_major_modal h3 {
+    margin-top: 0;
+    margin-bottom: 15px;
+}
+
+.double_major_modal select {
+    padding: 6px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--bg-card);
+    color: var(--text-primary);
+    margin-bottom: 10px;
+}
+
+.double_major_modal .dm-buttons {
     display: flex;
     justify-content: flex-end;
     gap: 10px;


### PR DESCRIPTION
## Summary
- Make sidebar toggle visible when collapsed so the panel can reopen
- Restyle double major category picker to use shared modal styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891fdabf150832aa34dad9fc1e7a482