### PR TITLE
Show major names in summary modals

### DIFF
--- a/graduation_check.js
+++ b/graduation_check.js
@@ -45,8 +45,22 @@ function displayGraduationResults(curriculum) {
 function displaySummary(curriculum, major_chosen_by_user) {
     // Do not create more than one set of summary modals. If any exist, abort.
     if (document.querySelector('.summary_modal')) return;
+    const majorNames = {
+        CS: 'Computer Science and Engineering',
+        DSA: 'Data Science and Analytics',
+        ECON: 'Economics',
+        EE: 'Electronics Engineering',
+        IE: 'Industrial Engineering',
+        MAN: 'Management',
+        MAT: 'Materials Science and Nano Engineering',
+        ME: 'Mechatronics Engineering',
+        BIO: 'Molecular Biology, Genetics and Bioengineering',
+        PSIR: 'Political Science and International Relations',
+        PSY: 'Psychology',
+        VACD: 'Visual Arts and Visual Communications Design'
+    };
     // Helper to build a summary modal for a given set of totals and limits.
-    function buildSummaryModal(totals, limits, gpa, labelPrefix) {
+    function buildSummaryModal(totals, limits, gpa, majorCode) {
         // Overlay is shared by all summary modals. Create it on demand and
         // append to the body so it covers the full viewport. The overlay uses
         // flexbox centering so modals appear in the middle of the screen.
@@ -59,6 +73,12 @@ function displaySummary(curriculum, major_chosen_by_user) {
         const modal = document.createElement('div');
         modal.classList.add('summary_modal');
         overlay.appendChild(modal);
+        if (majorCode) {
+            const header = document.createElement('div');
+            header.classList.add('summary_modal_title');
+            header.textContent = majorNames[majorCode] || majorCode;
+            modal.appendChild(header);
+        }
         // Build content
         const labels = ['GPA: ', 'SU Credits: ', 'ECTS: ', 'University: ',  'Required: ', 'Core: ', 'Area: ', 'Free: ',  'Basic Science: ', 'Engineering: '];
         const total_values = [gpa, totals.total, totals.ects, totals.university, totals.required, totals.core, totals.area, totals.free, totals.science, totals.engineering];
@@ -127,7 +147,7 @@ function displaySummary(curriculum, major_chosen_by_user) {
         String(reqMain.engineering || 0)
     ];
     // Build primary summary modal
-    buildSummaryModal(totalsMain, limitsMain, gpaMain);
+    buildSummaryModal(totalsMain, limitsMain, gpaMain, major_chosen_by_user);
     // If a double major exists, compute totals for DM and show a second modal
     if (curriculum.doubleMajor) {
         let totalsDM = {
@@ -172,7 +192,7 @@ function displaySummary(curriculum, major_chosen_by_user) {
             String(dmReq.science || 0),
             String(dmReq.engineering || 0)
         ];
-        buildSummaryModal(totalsDM, limitsDM, gpaDM);
+        buildSummaryModal(totalsDM, limitsDM, gpaDM, curriculum.doubleMajor);
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1183,6 +1183,12 @@ html, body {
     color: var(--text-primary)
 }
 
+/* Title for the summary modal */
+.summary_modal_title {
+    text-align: center;
+    font-weight: bold;
+}
+
 /* Rows within the summary modal */
 .summary_modal_child {
     display: flex;


### PR DESCRIPTION
## Summary
- display full major names at top of summary modals
- add centered styling for summary modal titles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689202177154832a9f61459fe0c85e8d