### PR TITLE
Fix ghost semester placement and improve course addition UX

### DIFF
--- a/click.js
+++ b/click.js
@@ -55,6 +55,8 @@ function dynamic_click(e, curriculum, course_data)
         });
 
         e.target.parentNode.insertBefore(input_container, e.target.parentNode.querySelector(".addCourse"));
+        // Automatically focus the input so the user can start typing immediately
+        input1.focus();
     }
     //CLICKED "OK" (for entering course input):
     else if(e.target.classList.contains("enter"))

--- a/create_semester.js
+++ b/create_semester.js
@@ -152,9 +152,10 @@ function createSemeter(aslastelement=true, courseList=[], curriculum, course_dat
         newsem.termIndex = null;
     }
 
-    let addCourse = document.createElement("button");
+    // Ghost course placeholder similar to the ghost semester container
+    let addCourse = document.createElement("div");
     addCourse.classList.add("addCourse");
-    addCourse.innerHTML = "+ Add another course";
+    addCourse.innerHTML = "+ Add course";
 
 
     subcontainer.appendChild(semester);

--- a/main.js
+++ b/main.js
@@ -694,9 +694,6 @@ function SUrriculum(major_chosen_by_user) {
         }
     }
 
-    // Create ghost container on initial load
-    ensureGhostSemester();
-
     // Sidebar collapse toggle
     const sidebar = document.querySelector('.sidebar');
     const sidebarToggle = document.querySelector('.sidebar-toggle');
@@ -1136,6 +1133,8 @@ function SUrriculum(major_chosen_by_user) {
     } catch(err) {
         // ignore
     }
+    // Ensure the ghost semester container is appended after reloading existing semesters
+    ensureGhostSemester();
     //Save:
     saveInterval = setInterval(function() {
         localStorage.removeItem("curriculum");

--- a/styles.css
+++ b/styles.css
@@ -1007,24 +1007,20 @@ html, body {
 
 /* Add course button within a semester */
 .addCourse {
-    display: inline-flex;
+    margin: 8px 0;
+    border: 2px dashed var(--border);
+    border-radius: var(--radius-sm);
+    min-height: 60px;
+    display: flex;
     align-items: center;
     justify-content: center;
-    padding: 6px 12px;
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--primary);
-    background: var(--bg-surface);
-    border: 1px dashed var(--primary);
-    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
     cursor: pointer;
-    transition: all 0.15s ease;
-    flex-shrink: 0; /* Keep button visible */
+    transition: background 0.15s ease;
 }
 
 .addCourse:hover {
-    background: var(--bg-main);
-    border-style: solid;
+    background: var(--bg-surface);
 }
 
 /* Input container for adding a course */
@@ -1100,7 +1096,8 @@ html, body {
 .change_major input,
 .doubleMajor input,
 .entryTerm input,
-.entryTermDM input {
+.entryTermDM input,
+.date input {
     padding: 4px 8px;
     font-size: 0.75rem;
     border: 1px solid var(--border);
@@ -1114,7 +1111,8 @@ html, body {
 .change_major input:focus,
 .doubleMajor input:focus,
 .entryTerm input:focus,
-.entryTermDM input:focus {
+.entryTermDM input:focus,
+.date input:focus {
     border-color: var(--primary);
 }
 


### PR DESCRIPTION
## Summary
- Ensure the “New Semester” ghost stays at the end by creating it after stored semesters are loaded
- Style semester term editor to match other select boxes and revamp course addition as a ghost card
- Auto-focus course input when adding and provide larger ghost add-course elements

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689208956de8832a88f4aa09ae1d2902