### PR TITLE
Focus input when selecting majors and admit terms

### DIFF
--- a/main.js
+++ b/main.js
@@ -435,6 +435,7 @@ function SUrriculum(major_chosen_by_user) {
                 });
                 change_major_element.appendChild(inputMajor);
                 change_major_element.appendChild(datalist);
+                inputMajor.focus();
                 inputMajor.addEventListener('input', function(e2) {
                     const majorChosenNew = (e2.target.value || '').toUpperCase();
                     // Validate against available majors in the datalist
@@ -497,6 +498,7 @@ function SUrriculum(major_chosen_by_user) {
                     });
                     double_major_element.appendChild(dmInput);
                     double_major_element.appendChild(dmDatalist);
+                    dmInput.focus();
                     dmInput.addEventListener('input', function(e2) {
                         let newVal = (e2.target.value || '').toUpperCase();
                         if (newVal === 'NONE' || newVal === '') {
@@ -580,6 +582,7 @@ function SUrriculum(major_chosen_by_user) {
                     dl.id = 'datalist_terms';
                     entryTerms.forEach(function(t){ dl.innerHTML += `<option value='${t}'>`; });
                     entry_term_el.appendChild(inp); entry_term_el.appendChild(dl);
+                    inp.focus();
                     inp.addEventListener('input', function(ev){
                         if (entryTerms.indexOf(ev.target.value) !== -1) {
                             localStorage.setItem('entryTerm', ev.target.value);
@@ -608,6 +611,7 @@ function SUrriculum(major_chosen_by_user) {
                     dl.id = 'datalist_terms_dm';
                     entryTerms.forEach(function(t){ dl.innerHTML += `<option value='${t}'>`; });
                     entry_term_dm_el.appendChild(inp); entry_term_dm_el.appendChild(dl);
+                    inp.focus();
                     inp.addEventListener('input', function(ev){
                         if (entryTerms.indexOf(ev.target.value) !== -1) {
                             localStorage.setItem('entryTermDM', ev.target.value);


### PR DESCRIPTION
## Summary
- focus the search input when choosing a major or double major
- focus the admit term input for both primary and double majors

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_6892fbbeb15c832aa5eefa7135cd5487