### PR TITLE
Improve course selection input UX

### DIFF
--- a/click.js
+++ b/click.js
@@ -25,7 +25,8 @@ function dynamic_click(e, curriculum, course_data)
         input_container.classList.add("input_container")
 
         let input = document.createElement("input");
-        input.classList.add("course_select");
+        // Use same styling as other dropdowns for a consistent UI
+        input.classList.add("course_select", "select-control");
         const listId = 'course_list_' + Date.now();
         input.setAttribute('list', listId);
         let datalist = document.createElement('datalist');
@@ -43,7 +44,20 @@ function dynamic_click(e, curriculum, course_data)
         input_container.appendChild(delete_ac);
 
         e.target.parentNode.insertBefore(input_container, e.target.parentNode.querySelector(".addCourse"));
-        input.focus();
+
+        // Automatically focus and open the course list so the user can start typing immediately
+        setTimeout(() => {
+            input.focus();
+            // showPicker is supported in modern browsers; fall back to simulating
+            // a key press for others to trigger the datalist suggestions
+            if (typeof input.showPicker === 'function') {
+                try { input.showPicker(); } catch (_) {}
+            } else {
+                const evt = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
+                input.dispatchEvent(evt);
+            }
+        }, 0);
+
         input.addEventListener('keydown', function(evt){
             if(evt.key === 'Enter') {
                 enter.click();

--- a/styles.css
+++ b/styles.css
@@ -1053,10 +1053,10 @@ html, body {
 .input_container input,
 .input_container select {
     flex: 1;
-    padding: 4px 8px;
+    padding: 6px 12px;
     font-size: 0.75rem;
     border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
+    border-radius: var(--radius-md);
     background: var(--bg-card);
     color: var(--text-primary);
     max-width: 250px;


### PR DESCRIPTION
## Summary
- style course add input to match other dropdown controls
- auto-focus and open course list when adding a course for quicker entry
- allow typing and pressing Enter to add courses smoothly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68930feccc4c832a875d097ab552dc80