### PR TITLE
Fix delete icon hover and reposition add-course dropdown

### DIFF
--- a/mouse_and_drag.js
+++ b/mouse_and_drag.js
@@ -64,7 +64,11 @@ function mouseout(e)
     }
     else if(e.target.classList.contains("delete_add_course") || e.target.classList.contains("delete_course"))
     {
-        e.target.style.backgroundImage = "url('./assets/closed.png')";
+        // Restore the original delete icon color when the pointer leaves
+        // the element. Previously this used `closed.png`, which left the
+        // icon black after the first hover. Matching the default
+        // `closedb.png` ensures the icon returns to its initial blue tint.
+        e.target.style.backgroundImage = "url('./assets/closedb.png')";
     }
     else if(e.target.classList.contains("enter"))
     {

--- a/styles.css
+++ b/styles.css
@@ -1080,9 +1080,11 @@ html, body {
 /* Custom dropdown for course suggestions */
 .input_container .course-dropdown {
     position: absolute;
-    top: 100%;
+    top: auto;
+    bottom: 100%;
     left: 0;
     right: 0;
+    margin-bottom: 4px;
     background: var(--bg-card);
     border: 1px solid var(--border);
     border-radius: var(--radius-sm);


### PR DESCRIPTION
## Summary
- Restore original delete icon color after hover to prevent it from staying black.
- Display Add Course suggestion dropdown above the input for better visibility near page bottom.

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689324b36854832aa0f3a123f875cf38