### PR TITLE
Fix semester icon visibility in light mode

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # Mark specific file as generated
-Academic\ Records\ Summary_ex.html linguist-generated=true
+"Academic Records Summary_ex.html" linguist-generated=true
 
 # Mark entire directories as generated
-Degree\ Detail\ Pages\/* linguist-generated=true
-Pre-Conversion\ Files\/* linguist-generated=true
+"Degree Detail Pages/*" linguist-generated=true
+"Pre-Conversion Files/*" linguist-generated=true

--- a/main.js
+++ b/main.js
@@ -272,13 +272,11 @@ function SUrriculum(major_chosen_by_user) {
         mouseover(e);
         if (e.target.classList.contains('btn'))
         {e.target.style.backgroundColor = '#7a9dc9';}
-        else if(e.target.parentNode.classList.contains('btn'))
+        else if(e.target.parentNode.classList && e.target.parentNode.classList.contains('btn'))
         {e.target.parentNode.style.backgroundColor = '#7a9dc9';}
         else
         {
             document.querySelectorAll('.btn').forEach( element => {element.style.backgroundColor = '#526e8f'});
-            if(!e.target.classList.contains('semester_drag'))
-            {document.querySelectorAll('.semester_drag').forEach( element => {element.style.backgroundImage = 'url("./assets/dragw.png")'});}
         }
     })
     document.addEventListener('mouseout', function(e){

--- a/mouse_and_drag.js
+++ b/mouse_and_drag.js
@@ -1,17 +1,8 @@
 function mouseover(e)
 {
-    if(e.target.classList.contains("delete_semester"))
+    if(e.target.classList.contains("semester_drag"))
     {
-        e.target.style.backgroundImage = "url('./assets/closedb.png')";
-    }
-    else if(e.target.classList.contains("semester_drag"))
-    {
-        e.target.style.backgroundImage = "url('./assets/dragb.png')";
         e.target.parentNode.parentNode.parentNode.parentNode.setAttribute('draggable','true');
-    }
-    else if(e.target.classList.contains("semester_date_edit"))
-    {
-        e.target.style.backgroundImage = "url('./assets/editb.png')";
     }
     else if(e.target.classList.contains("tick"))
     {
@@ -19,11 +10,11 @@ function mouseover(e)
     }
     else if(e.target.classList.contains("addCourse"))
     {
-        e.target.style.textDecoration = "underline"
+        e.target.style.textDecoration = "underline";
     }
     else if(e.target.classList.contains("grade"))
     {
-        e.target.style.textDecoration = "underline"
+        e.target.style.textDecoration = "underline";
     }
     else if(e.target.classList.contains("delete_add_course") || e.target.classList.contains("delete_course"))
     {
@@ -37,18 +28,9 @@ function mouseover(e)
 
 function mouseout(e)
 {
-    if(e.target.classList.contains("delete_semester"))
+    if(e.target.classList.contains("semester_drag"))
     {
-        e.target.style.backgroundImage = "url('./assets/closedw.png')";
-    }
-    else if(e.target.classList.contains("semester_drag"))
-    {
-        e.target.style.backgroundImage = "url('./assets/dragw.png')";
         e.target.parentNode.parentNode.parentNode.parentNode.setAttribute('draggable','false');
-    }
-    else if(e.target.classList.contains("semester_date_edit"))
-    {
-        e.target.style.backgroundImage = "url('./assets/editw.png')";
     }
     else if(e.target.classList.contains("tick"))
     {
@@ -56,11 +38,11 @@ function mouseout(e)
     }
     else if(e.target.classList.contains("addCourse"))
     {
-        e.target.style.textDecoration = "none"
+        e.target.style.textDecoration = "none";
     }
     else if(e.target.classList.contains("grade"))
     {
-        e.target.style.textDecoration = "none"
+        e.target.style.textDecoration = "none";
     }
     else if(e.target.classList.contains("delete_add_course") || e.target.classList.contains("delete_course"))
     {


### PR DESCRIPTION
## Summary
- keep semester action icons visible in light theme by removing JS overrides that forced white icons
- update event handlers to only adjust button state and dragging
- quote paths with spaces in `.gitattributes`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689337894810832a908a20c3509e37fd