### PR TITLE
Add robots.txt with sitemap and signmap rules

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+Sitemap: https://beficent.github.io/surriculum/sitemap.xml
+Signmap: https://beficent.github.io/surriculum/signmap.xml

--- a/signmap.xml
+++ b/signmap.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<signmap>
-  <url>
-    <loc>https://beficent.github.io/surriculum/</loc>
-  </url>
-</signmap>

--- a/signmap.xml
+++ b/signmap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<signmap>
+  <url>
+    <loc>https://beficent.github.io/surriculum/</loc>
+  </url>
+</signmap>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://beficent.github.io/surriculum/</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- update robots.txt to reference sitemap and signmap on befisent.github.io/surriculum
- add sitemap.xml for the site
- add signmap.xml placeholder

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893570092a4832ab9cef42410c42201