### PR TITLE
Add WebApplication structured data

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,15 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebApplication",
+      "name": "SUrriculum",
+      "url": "https://beficent.github.io/surriculum/",
+      "description": "SUrriculum helps Sabancı University students plan their curriculum and track graduation requirements."
+    }
+    </script>
 
     <!-- Core scripts -->
     <script src="helper_functions.js"></script>


### PR DESCRIPTION
## Summary
- add WebApplication schema LD+JSON to index.html head for SEO

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `curl -s -X POST -H 'Content-Type: application/json' --data '{"url": "https://beficent.github.io/surriculum/"}' 'https://search.google.com/test/rich-results/api/validate' | head -n 20` *(404 Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_68935a86eee0832a9e593df2633d8e99