### PR TITLE
Add social media meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
     <meta name="keywords" content="curriculum planner, sabanci university, degree planning, graduation requirements">
     <meta name="google-site-verification" content="A01mm05EYD3vsvckKc6Yi7wwoQCeAMGOEApAQ7lTmw8" />
     <link rel="canonical" href="https://beficent.github.io/surriculum/">
+    <meta property="og:title" content="SUrriculum" />
+    <meta property="og:description" content="Plan your curriculum and track graduation requirements." />
+    <meta property="og:url" content="https://beficent.github.io/surriculum/" />
+    <meta property="og:image" content="https://beficent.github.io/surriculum/assets/sabanci.jpg" />
+    <meta name="twitter:card" content="summary_large_image" />
     <title>SUrriculum -v2.4 (beta)</title>
     <link rel="stylesheet" href="styles.css" type="text/css"/>
     <link rel="icon" href="assets/favicon.ico" type="image/ico">


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter card meta tags for improved link previews
- reference hosted preview image `assets/sabanci.jpg`

## Testing
- `npm test` *(fails: package.json not found)*
- `pytest` *(no tests discovered)*

------
https://chatgpt.com/codex/tasks/task_e_6893625d61c4832aaf7e529da3e3a5b1