### PR TITLE
Add touch drag-and-drop support

### DIFF
--- a/main.js
+++ b/main.js
@@ -300,6 +300,28 @@ function SUrriculum(major_chosen_by_user) {
         // curriculum.recalcEffectiveTypes() when semesters are reordered.
         drop(e, curriculum, dragged_item, course_data);
     })
+
+    // Touch-based dragging support mirrors the desktop drag events so that
+    // semesters can be reordered on touch devices.  We leverage touch
+    // coordinates on touchend to determine the drop target and prevent the
+    // page from scrolling while a semester is being dragged.
+    document.addEventListener('touchstart', function(e){
+        const container = getAncestor(e.target, 'container_semester');
+        if(container){ dragged_item = container; }
+    })
+    document.addEventListener('touchmove', function(e){
+        if(dragged_item){
+            // Prevent viewport scrolling while dragging a semester
+            e.preventDefault();
+        }
+    }, {passive:false})
+    document.addEventListener('touchend', function(e){
+        if(dragged_item){
+            const touch = e.changedTouches[0];
+            drop(e, curriculum, dragged_item, course_data, {x: touch.clientX, y: touch.clientY});
+            dragged_item = null;
+        }
+    })
     /*
     document.addEventListener("input", function(e){
         if(e.target.classList.contains())

--- a/mouse_and_drag.js
+++ b/mouse_and_drag.js
@@ -58,12 +58,24 @@ function mouseout(e)
     }
 }
 
-function drop(e, curriculum, dragged_item, course_data)
+function drop(e, curriculum, dragged_item, course_data, touchPos)
 {
-    let container = getAncestor(e.target, "container_semester");
+    // Prevent default browser behavior (such as scrolling) during a drop
+    if(e && typeof e.preventDefault === 'function'){
+        e.preventDefault();
+    }
+
+    // Determine the drop target. For mouse events we use e.target directly.
+    // For touch interactions we resolve the element at the touch coordinates
+    // supplied via touchPos.
+    let targetElement = e.target;
+    if(touchPos && typeof document !== 'undefined' && document.elementFromPoint){
+        targetElement = document.elementFromPoint(touchPos.x, touchPos.y);
+    }
+    let container = getAncestor(targetElement, "container_semester");
     if(container)
     {
-        let target_id = extractNumericValue(container.id); 
+        let target_id = extractNumericValue(container.id);
         let dragged_id = extractNumericValue(dragged_item.id);
 
         if(target_id > dragged_id)


### PR DESCRIPTION
## Summary
- Add touch event listeners to enable dragging semesters on touch devices
- Extend drop handler to use touch coordinates and block scrolling during touch drag

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check main.js`
- `node --check mouse_and_drag.js`


------
https://chatgpt.com/codex/tasks/task_e_68945813e3c0832a8d7e61a8fdb11b08