### PR TITLE
Restrict touch reordering to drag handle

### DIFF
--- a/main.js
+++ b/main.js
@@ -306,8 +306,11 @@ function SUrriculum(major_chosen_by_user) {
     // coordinates on touchend to determine the drop target and prevent the
     // page from scrolling while a semester is being dragged.
     document.addEventListener('touchstart', function(e){
-        const container = getAncestor(e.target, 'container_semester');
-        if(container){ dragged_item = container; }
+        // Only begin dragging if the user taps the dedicated drag handle.
+        const handle = getAncestor(e.target, 'semester_drag');
+        if(handle){
+            dragged_item = getAncestor(handle, 'container_semester');
+        }
     })
     document.addEventListener('touchmove', function(e){
         if(dragged_item){


### PR DESCRIPTION
## Summary
- Avoid blocking horizontal scroll on mobile by only enabling semester drag when the drag handle is touched

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68945e25ae8c832ab332ccacb6474380