### PR TITLE
Add PWA manifest and service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,8 @@
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="192x192" href="assets/android-chrome-192x192.png">
     <link rel="icon" type="image/png" sizes="512x512" href="assets/android-chrome-512x512.png">
-    
+
+    <link rel="manifest" href="manifest.json">
     <link rel="apple-touch-icon" sizes="180x180" href="assets/apple-touch-icon.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/main.js
+++ b/main.js
@@ -11,6 +11,12 @@ let course_data;
 let initial_major_chosen = 'CS'
 let saveInterval;
 
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('sw.js');
+    });
+}
+
 
 function SUrriculum(major_chosen_by_user) {
     /**

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,25 @@
+{
+  "name": "SUrriculum",
+  "short_name": "SUrriculum",
+  "icons": [
+    {
+      "src": "assets/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "assets/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "assets/apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png"
+    }
+  ],
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff"
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,20 @@
+const CACHE_NAME = 'surriculum-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/styles.css',
+  '/main.js',
+  '/manifest.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- Add web app manifest defining icons, name, and display settings.
- Implement service worker caching core assets for offline support and register it on page load.
- Link manifest in `index.html` to enable PWA features.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68947620c8b8832a96cf21f090dc5691