### PR TITLE
Use flexible height for semester containers

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -285,7 +285,7 @@ html, body {
     font-size: 0.8rem;
 }
 
-/* === SEMESTER CONTAINER - FIXED FOR SCROLLING === */
+/* === SEMESTER CONTAINER - FILL AVAILABLE HEIGHT === */
 .semester-container {
     width: var(--semester-width);
     margin: 20px;
@@ -298,7 +298,7 @@ html, body {
     box-shadow: var(--shadow-md);
     /* Allow dropdowns to extend outside the semester card */
     overflow: visible;
-    height: calc(100vh - 140px); /* Fixed height based on viewport */
+    height: 100%; /* Take remaining height between header and footer */
     display: flex;
     flex-direction: column;
     min-height: 300px;
@@ -813,9 +813,9 @@ html, body {
     scrollbar-width: thin;
     scrollbar-color: #4facfe transparent;
 }
-/* === LEGACY COMPATIBILITY - FIXED FOR SCROLLING === */
+/* === LEGACY COMPATIBILITY - FLEXIBLE HEIGHT === */
 
-/* Each semester column - FIXED HEIGHT AND FLEX LAYOUT */
+/* Each semester column - FLEX LAYOUT USING AVAILABLE HEIGHT */
 .container_semester {
     background: var(--bg-card);
     border: 1px solid var(--border);
@@ -826,7 +826,7 @@ html, body {
     flex-direction: column;
     box-shadow: var(--shadow-sm);
     overflow: hidden;
-    height: calc(100vh - 140px); /* Fixed height for proper scrolling */
+    height: 100%; /* Take remaining height between header and footer */
 }
 
 /* Placeholder container for adding new semesters inline */
@@ -835,7 +835,7 @@ html, body {
     flex: 0 0 var(--semester-width);
     border: 2px dashed var(--border);
     border-radius: var(--radius-md);
-    height: calc(100vh - 140px);
+    height: 100%;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## Summary
- Let semester columns grow to fill leftover space between header and footer by replacing viewport-based height with 100% height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68949024488c832a83068f9060db304d