### PR TITLE
feat: animate board scroll on adding semester

### DIFF
--- a/main.js
+++ b/main.js
@@ -348,7 +348,7 @@ function SUrriculum(major_chosen_by_user) {
             board.insertBefore(newContainer, ghost);
             const style = getComputedStyle(newContainer);
             const width = newContainer.offsetWidth + parseInt(style.marginLeft) + parseInt(style.marginRight);
-            board.scrollLeft += width;
+            board.scrollBy({ left: width, behavior: 'smooth' });
         }
     });
 
@@ -365,7 +365,7 @@ function SUrriculum(major_chosen_by_user) {
                 const style = getComputedStyle(newContainer);
                 const width = newContainer.offsetWidth + parseInt(style.marginLeft) + parseInt(style.marginRight);
                 board.insertBefore(newContainer, ghost);
-                board.scrollLeft += width;
+                board.scrollBy({ left: width, behavior: 'smooth' });
             });
             board.appendChild(ghost);
         }


### PR DESCRIPTION
## Summary
- animate horizontal scroll when inserting new semester to show movement

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689497fa8f7c832a847b7c142aef85f7