### PR TITLE
Add PDF transcript import support

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,12 +106,12 @@
                         <p>Import your courses from Academic Records Summary:</p>
                         <ol>
                             <li>Go to SUIS → Student → Student Records → Academic Transcript and view your Academic Records Summary</li>
-                            <li>Save the page as HTML (right-click → Save as... → HTML only)</li>
-                            <li>Upload the saved HTML file below</li>
+                            <li>Save the page as <strong>HTML (preferred)</strong> or print to <strong>PDF</strong></li>
+                            <li>Upload the saved HTML or PDF file below</li>
                         </ol>
                     </div>
                     <div class="import-controls">
-                        <input type="file" id="academicRecordsInput" class="import-file" accept=".html,.htm">
+                        <input type="file" id="academicRecordsInput" class="import-file" accept=".html,.htm,.pdf">
                         <button id="importAcademicRecords" class="btn btn-primary btn-sm">Import</button>
                     </div>
                     <div id="course-import-box" style="margin-top: 12px; padding: 12px; background: var(--bg-surface); border-radius: var(--radius-sm); font-size: 0.875rem; color: var(--text-primary);">


### PR DESCRIPTION
## Summary
- allow importing Academic Records PDF by parsing extracted text
- update import UI to accept HTML or PDF files
- handle PDF/HTML parsing in import flow

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/surriculum/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6894b1ddd898832aa4cd72b3954cfff8