### PR TITLE
feat: add course detail toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,6 +171,16 @@
                 </div>
 
                 <div class="control-group">
+                    <div class="control-row toggle-row">
+                        <span class="toggle-text">Show Course Details</span>
+                        <label class="toggle-switch">
+                            <input type="checkbox" id="courseDetailsToggle">
+                            <span class="toggle-slider"></span>
+                        </label>
+                    </div>
+                </div>
+
+                <div class="control-group">
                     <button class="btn btn-secondary deleteCustom" style="width: 100%; margin-bottom: 12px; color: #DC2626;">
                         <i class="fa-solid fa-trash"></i>&nbsp;Delete Custom Courses
                     </button>

--- a/main.js
+++ b/main.js
@@ -255,6 +255,24 @@ function SUrriculum(major_chosen_by_user) {
     if (typeof window !== 'undefined') {
         window.curriculum = curriculum;
     }
+    // Initialize course details toggle state and event
+    let showDetails = false;
+    try { showDetails = localStorage.getItem('showCourseDetails') === 'true'; } catch (_) {}
+    if (typeof window !== 'undefined') {
+        window.showCourseDetails = showDetails;
+    }
+    const detailsToggle = document.getElementById('courseDetailsToggle');
+    if (detailsToggle) {
+        detailsToggle.checked = showDetails;
+        detailsToggle.addEventListener('change', function(e) {
+            const enabled = e.target.checked;
+            if (typeof window !== 'undefined') {
+                window.showCourseDetails = enabled;
+            }
+            try { localStorage.setItem('showCourseDetails', enabled ? 'true' : 'false'); } catch (_) {}
+            document.dispatchEvent(new Event('courseDetailsToggleChanged'));
+        });
+    }
 
     //************************************************
 

--- a/scripts/click.js
+++ b/scripts/click.js
@@ -46,16 +46,32 @@ function dynamic_click(e, curriculum, course_data)
         // Build array of course options for filtering
         const options = getCoursesList(course_data);
 
+        function formatOption(item) {
+            const base = item.code + ' ' + item.name;
+            if (window.showCourseDetails) {
+                const parts = [
+                    'Credits: ' + item.credit,
+                    'BS: ' + item.bs
+                ];
+                if (item.type) parts.push('Major: ' + item.type);
+                if (item.dmType) parts.push('DM: ' + item.dmType);
+                return base + ' [' + parts.join(', ') + ']';
+            }
+            return base;
+        }
+
         function renderOptions(filter) {
             dropdown.innerHTML = '';
             const normalized = filter ? filter.toUpperCase() : '';
-            const filtered = options.filter(o => o.toUpperCase().includes(normalized));
-            filtered.forEach(text => {
+            const filtered = options.filter(o => (o.code + ' ' + o.name).toUpperCase().includes(normalized));
+            filtered.forEach(data => {
                 const opt = document.createElement('div');
                 opt.classList.add('course-option');
-                opt.textContent = text;
+                opt.dataset.code = data.code;
+                opt.dataset.name = data.name;
+                opt.textContent = formatOption(data);
                 opt.addEventListener('mousedown', () => {
-                    input.value = text;
+                    input.value = data.code + ' ' + data.name;
                     dropdown.style.display = 'none';
                 });
                 dropdown.appendChild(opt);
@@ -90,10 +106,14 @@ function dynamic_click(e, curriculum, course_data)
                 evt.preventDefault();
             } else if (evt.key === 'Enter') {
                 if (activeIndex >= 0 && items[activeIndex]) {
-                    input.value = items[activeIndex].textContent;
+                    input.value = items[activeIndex].dataset.code + ' ' + items[activeIndex].dataset.name;
                 }
                 enter.click();
             }
+        });
+
+        document.addEventListener('courseDetailsToggleChanged', () => {
+            renderOptions(input.value);
         });
 
         let enter = document.createElement("div");

--- a/styles.css
+++ b/styles.css
@@ -281,6 +281,60 @@ html, body {
     font-size: 0.8rem;
 }
 
+.control-row.toggle-row {
+    justify-content: space-between;
+    align-items: center;
+}
+
+.toggle-text {
+    font-size: 0.8rem;
+}
+
+.toggle-switch {
+    position: relative;
+    display: inline-block;
+    width: 40px;
+    height: 20px;
+}
+
+.toggle-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.toggle-slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: var(--border);
+    transition: 0.2s;
+    border-radius: 20px;
+}
+
+.toggle-slider:before {
+    position: absolute;
+    content: "";
+    height: 16px;
+    width: 16px;
+    left: 2px;
+    bottom: 2px;
+    background-color: var(--bg-card);
+    transition: 0.2s;
+    border-radius: 50%;
+}
+
+.toggle-switch input:checked + .toggle-slider {
+    background-color: var(--accent);
+}
+
+.toggle-switch input:checked + .toggle-slider:before {
+    transform: translateX(20px);
+}
+
 .select-control {
     flex-grow: 1;
     font-size: 0.8rem;


### PR DESCRIPTION
## Summary
- add sidebar toggle to show course details in dropdown suggestions
- persist toggle state in local storage and update dropdown rendering with credits and requirement types
- style custom toggle switch

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895cf542a98832aa2251599c5baccb8