### PR TITLE
Improve course dropdown readability

### DIFF
--- a/scripts/click.js
+++ b/scripts/click.js
@@ -47,17 +47,18 @@ function dynamic_click(e, curriculum, course_data)
         const options = getCoursesList(course_data);
 
         function formatOption(item) {
-            const base = item.code + ' ' + item.name;
+            const title = `<div class="course-option-title">${item.code} ${item.name}</div>`;
             if (window.showCourseDetails) {
                 const parts = [
-                    'Credits: ' + item.credit,
-                    'BS: ' + item.bs
+                    `Credits: ${item.credit}`,
+                    `BS: ${item.bs}`
                 ];
-                if (item.type) parts.push('Major: ' + item.type);
-                if (item.dmType) parts.push('DM: ' + item.dmType);
-                return base + ' [' + parts.join(', ') + ']';
+                if (item.type) parts.push(`Major: ${item.type}`);
+                if (item.dmType) parts.push(`DM: ${item.dmType}`);
+                const details = parts.map(p => `<div>${p}</div>`).join('');
+                return title + `<div class="course-option-details">${details}</div>`;
             }
-            return base;
+            return title;
         }
 
         function renderOptions(filter) {
@@ -69,7 +70,7 @@ function dynamic_click(e, curriculum, course_data)
                 opt.classList.add('course-option');
                 opt.dataset.code = data.code;
                 opt.dataset.name = data.name;
-                opt.textContent = formatOption(data);
+                opt.innerHTML = formatOption(data);
                 opt.addEventListener('mousedown', () => {
                     input.value = data.code + ' ' + data.name;
                     dropdown.style.display = 'none';

--- a/styles.css
+++ b/styles.css
@@ -1283,6 +1283,23 @@ html, body {
     cursor: pointer;
 }
 
+.input_container .course-option-title {
+    font-weight: 600;
+}
+
+.input_container .course-option-details {
+    margin-top: 2px;
+    font-size: 0.85em;
+    color: var(--text-secondary);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 8px;
+}
+
+.input_container .course-option-details div {
+    white-space: nowrap;
+}
+
 .input_container .course-option:hover,
 .input_container .course-option.active {
     background: var(--bg-surface);


### PR DESCRIPTION
## Summary
- Present course details in multiline format within the Add Course dropdown
- Style dropdown options for clearer title and detail separation

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6895d39e33f0832a9a8791f059736dd5