### PR TITLE
feat: allow hiding taken courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The interface allows you to:
 - Toggle between light and dark themes or follow your system preference
 - Collapse the sidebar to maximize planning space
 - Insert new semesters and courses using "+ New Semester" and "+ Add course" ghosts
+- Hide courses you've already added using the "Hide Taken Courses" toggle
 
 Always verify graduation requirements yourself. For issues or suggestions, contact [bilal.gebenoglu@sabanciuniv.edu](mailto:bilal.gebenoglu@sabanciuniv.edu), or start a discussion/issue on the repository.
 

--- a/index.html
+++ b/index.html
@@ -181,6 +181,16 @@
                 </div>
 
                 <div class="control-group">
+                    <div class="control-row toggle-row">
+                        <span class="toggle-text">Hide Taken Courses</span>
+                        <label class="toggle-switch">
+                            <input type="checkbox" id="hideTakenCoursesToggle">
+                            <span class="toggle-slider"></span>
+                        </label>
+                    </div>
+                </div>
+
+                <div class="control-group">
                     <button class="btn btn-secondary deleteCustom" style="width: 100%; margin-bottom: 12px; color: #DC2626;">
                         <i class="fa-solid fa-trash"></i>&nbsp;Delete Custom Courses
                     </button>

--- a/main.js
+++ b/main.js
@@ -274,6 +274,24 @@ function SUrriculum(major_chosen_by_user) {
         });
     }
 
+    let hideTaken = false;
+    try { hideTaken = localStorage.getItem('hideTakenCourses') === 'true'; } catch (_) {}
+    if (typeof window !== 'undefined') {
+        window.hideTakenCourses = hideTaken;
+    }
+    const hideToggle = document.getElementById('hideTakenCoursesToggle');
+    if (hideToggle) {
+        hideToggle.checked = hideTaken;
+        hideToggle.addEventListener('change', function(e) {
+            const enabled = e.target.checked;
+            if (typeof window !== 'undefined') {
+                window.hideTakenCourses = enabled;
+            }
+            try { localStorage.setItem('hideTakenCourses', enabled ? 'true' : 'false'); } catch (_) {}
+            document.dispatchEvent(new Event('hideTakenCoursesToggleChanged'));
+        });
+    }
+
     //************************************************
 
     //Targetting dynamically created elements:

--- a/scripts/click.js
+++ b/scripts/click.js
@@ -44,7 +44,7 @@ function dynamic_click(e, curriculum, course_data)
         dropdown.classList.add('course-dropdown');
 
         // Build array of course options for filtering
-        const options = getCoursesList(course_data);
+        let options = getCoursesList(course_data);
 
         function capitalizeFirst(str) {
             return str.charAt(0).toUpperCase() + str.slice(1);
@@ -118,6 +118,11 @@ function dynamic_click(e, curriculum, course_data)
         });
 
         document.addEventListener('courseDetailsToggleChanged', () => {
+            renderOptions(input.value);
+        });
+        document.addEventListener('hideTakenCoursesToggleChanged', () => {
+            options = getCoursesList(course_data);
+            datalist.innerHTML = getCoursesDataList(course_data);
             renderOptions(input.value);
         });
 

--- a/scripts/helper_functions.js
+++ b/scripts/helper_functions.js
@@ -179,8 +179,11 @@ function getCoursesDataList(course_data)
                 }
             });
         }
+        if (typeof window !== 'undefined' && window.hideTakenCourses && cur && typeof cur.hasCourse === 'function') {
+            combined = combined.filter(c => !cur.hasCourse(c.Major + c.Code));
+        }
     } catch (ex) {
-        // ignore any errors in DM detection
+        // ignore any errors in DM detection or filtering
     }
     // Build the option list HTML using the combined courses. Each option
     // displays the course code followed by the course name and uses the
@@ -212,6 +215,9 @@ function getCoursesList(course_data) {
                     combined.push(dm);
                 }
             });
+        }
+        if (typeof window !== 'undefined' && window.hideTakenCourses && cur && typeof cur.hasCourse === 'function') {
+            combined = combined.filter(c => !cur.hasCourse(c.Major + c.Code));
         }
     } catch (_) {}
 


### PR DESCRIPTION
## Summary
- add "Hide Taken Courses" switch to sidebar
- support persistence and event handling for new switch
- filter taken courses out of course dropdowns

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895d7b1aae4832a964372a9fe36bd14