### PR TITLE
Display Basic Science credits with course details

### DIFF
--- a/main.js
+++ b/main.js
@@ -274,6 +274,15 @@ function SUrriculum(major_chosen_by_user) {
         });
     }
 
+    const updateCourseDetailVisibility = () => {
+        const show = window.showCourseDetails;
+        document.querySelectorAll('.course_bs_credit').forEach(el => {
+            el.style.display = show ? '' : 'none';
+        });
+    };
+    document.addEventListener('courseDetailsToggleChanged', updateCourseDetailVisibility);
+    updateCourseDetailVisibility();
+
     let hideTaken = false;
     try { hideTaken = localStorage.getItem('hideTakenCourses') === 'true'; } catch (_) {}
     if (typeof window !== 'undefined') {

--- a/scripts/click.js
+++ b/scripts/click.js
@@ -237,6 +237,13 @@ function dynamic_click(e, curriculum, course_data)
             c_info.innerHTML = '<div class="course_name">'+ info['Course_Name'] +'</div>';
             c_info.innerHTML += '<div class="course_type">'+ info['EL_Type'].toUpperCase() + '</div>';
             c_info.innerHTML += '<div class="course_credit">' + info['SU_credit']+ '.0 credits </div>';
+            const bsDiv = document.createElement('div');
+            bsDiv.classList.add('course_bs_credit');
+            bsDiv.textContent = 'Basic Science: ' + (info['Basic_Science'] || '0') + ' credits';
+            if (!window.showCourseDetails) {
+                bsDiv.style.display = 'none';
+            }
+            c_info.appendChild(bsDiv);
             let grade = document.createElement('div');
             grade.classList.add('grade');
             grade.innerHTML = 'Add grade';

--- a/scripts/create_semester.js
+++ b/scripts/create_semester.js
@@ -212,6 +212,13 @@ function createSemeter(aslastelement=true, courseList=[], curriculum, course_dat
             //gr_container.classList.add('grade_container');
 
             c_info.innerHTML += '<div class="course_credit">' +courseCredit+ '.0 credits </div>';
+            const bsDiv = document.createElement('div');
+            bsDiv.classList.add('course_bs_credit');
+            bsDiv.textContent = 'Basic Science: ' + (getInfo(courseCode, course_data)['Basic_Science'] || '0') + ' credits';
+            if (!window.showCourseDetails) {
+                bsDiv.style.display = 'none';
+            }
+            c_info.appendChild(bsDiv);
             //gr_container.innerHTML += '<div class="grade">Add grade</div>';
             //c_info.appendChild(gr_container);
             var grade = document.createElement('div');

--- a/styles.css
+++ b/styles.css
@@ -1143,6 +1143,10 @@ html, body {
     color: var(--text-muted);
 }
 
+.course_info .course_bs_credit {
+    color: var(--text-muted);
+}
+
 /* RIGHT COLUMN - Grade */
 .grade {
     background: var(--bg-card);


### PR DESCRIPTION
## Summary
- show Basic Science credit line under each course when course details are enabled
- sync visibility of Basic Science credit lines with the course details toggle
- style Basic Science credit entries to match existing course credit text

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`
- `node --check main.js scripts/click.js scripts/create_semester.js`


------
https://chatgpt.com/codex/tasks/task_e_6895e8088464832aadbc3c641a1c3d58