### PR TITLE
Enable course details and hide taken toggles by default

### DIFF
--- a/main.js
+++ b/main.js
@@ -256,8 +256,11 @@ function SUrriculum(major_chosen_by_user) {
         window.curriculum = curriculum;
     }
     // Initialize course details toggle state and event
-    let showDetails = false;
-    try { showDetails = localStorage.getItem('showCourseDetails') === 'true'; } catch (_) {}
+    let showDetails = true;
+    try {
+        const saved = localStorage.getItem('showCourseDetails');
+        if (saved !== null) showDetails = saved === 'true';
+    } catch (_) {}
     if (typeof window !== 'undefined') {
         window.showCourseDetails = showDetails;
     }
@@ -274,8 +277,11 @@ function SUrriculum(major_chosen_by_user) {
         });
     }
 
-    let hideTaken = false;
-    try { hideTaken = localStorage.getItem('hideTakenCourses') === 'true'; } catch (_) {}
+    let hideTaken = true;
+    try {
+        const saved = localStorage.getItem('hideTakenCourses');
+        if (saved !== null) hideTaken = saved === 'true';
+    } catch (_) {}
     if (typeof window !== 'undefined') {
         window.hideTakenCourses = hideTaken;
     }


### PR DESCRIPTION
## Summary
- Default "Show Course Details" switch to on when no preference is stored
- Default "Hide Taken Courses" switch to on when no preference is stored

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895e8c01fb0832a91a01053d76e581b