### PR TITLE
Enable default course detail and hide taken toggles

### DIFF
--- a/main.js
+++ b/main.js
@@ -256,8 +256,13 @@ function SUrriculum(major_chosen_by_user) {
         window.curriculum = curriculum;
     }
     // Initialize course details toggle state and event
-    let showDetails = false;
-    try { showDetails = localStorage.getItem('showCourseDetails') === 'true'; } catch (_) {}
+    let showDetails = true;
+    try {
+        const stored = localStorage.getItem('showCourseDetails');
+        if (stored !== null) {
+            showDetails = stored === 'true';
+        }
+    } catch (_) {}
     if (typeof window !== 'undefined') {
         window.showCourseDetails = showDetails;
     }
@@ -283,8 +288,13 @@ function SUrriculum(major_chosen_by_user) {
     document.addEventListener('courseDetailsToggleChanged', updateCourseDetailVisibility);
     updateCourseDetailVisibility();
 
-    let hideTaken = false;
-    try { hideTaken = localStorage.getItem('hideTakenCourses') === 'true'; } catch (_) {}
+    let hideTaken = true;
+    try {
+        const stored = localStorage.getItem('hideTakenCourses');
+        if (stored !== null) {
+            hideTaken = stored === 'true';
+        }
+    } catch (_) {}
     if (typeof window !== 'undefined') {
         window.hideTakenCourses = hideTaken;
     }


### PR DESCRIPTION
## Summary
- Default "Show Course Details" and "Hide Taken Courses" toggles to enabled on first load
- Persist toggle states in localStorage, respecting existing user preferences

## Testing
- `node --check main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895f0445a28832a911bd813474b00e8