### PR TITLE
Fix GPA recalculation when removing ungraded courses

### DIFF
--- a/scripts/click.js
+++ b/scripts/click.js
@@ -323,8 +323,13 @@ function dynamic_click(e, curriculum, course_data)
         let dom_tc = e.target.parentNode.parentNode.parentNode.parentNode.parentNode.parentNode.querySelector('span');
         dom_tc.innerHTML = 'Total: ' + semObj.totalCredit + ' credits';
 
-        semObj.totalGPA -= (letter_grades_global_dic[grade] * credit);
-        if(grade != 'T'){semObj.totalGPACredits -= credit;}
+        const gradeValue = letter_grades_global_dic[grade];
+        if (gradeValue !== undefined) {
+            semObj.totalGPA -= gradeValue * credit;
+            if (grade !== 'T') {
+                semObj.totalGPACredits -= credit;
+            }
+        }
 
 
         e.target.parentNode.parentNode.parentNode.remove();
@@ -412,8 +417,13 @@ function dynamic_click(e, curriculum, course_data)
             let courseName = e.target.parentNode.querySelector('.course_label').firstChild.innerHTML;
             let credit = parseInt(getInfo(courseName, course_data)['SU_credit']);
 
-            curriculum.getSemester(sem.id).totalGPA -= (letter_grades_global_dic[prevGrade] * credit);
-            if(prevGrade != 'T'){curriculum.getSemester(sem.id).totalGPACredits -= credit;}
+            const prevGradeValue = letter_grades_global_dic[prevGrade];
+            if (prevGradeValue !== undefined) {
+                curriculum.getSemester(sem.id).totalGPA -= prevGradeValue * credit;
+                if (prevGrade !== 'T') {
+                    curriculum.getSemester(sem.id).totalGPACredits -= credit;
+                }
+            }
         }
 
         // Create modern dropdown
@@ -452,8 +462,13 @@ function dynamic_click(e, curriculum, course_data)
                 let courseName = gradeElement.parentNode.querySelector('.course_label').firstChild.innerHTML;
                 let credit = parseInt(getInfo(courseName, course_data)['SU_credit']);
                 let semObj = curriculum.getSemester(sem.id);
-                semObj.totalGPA += (letter_grades_global_dic[grade] * credit);
-                if(grade != 'T'){semObj.totalGPACredits += credit;}
+                const gradeValue = letter_grades_global_dic[grade];
+                if (gradeValue !== undefined) {
+                    semObj.totalGPA += gradeValue * credit;
+                    if (grade !== 'T') {
+                        semObj.totalGPACredits += credit;
+                    }
+                }
 
                 // Adjust earned credits
                 let info = getInfo(courseName, course_data);

--- a/scripts/create_semester.js
+++ b/scripts/create_semester.js
@@ -230,16 +230,19 @@ function createSemeter(aslastelement=true, courseList=[], curriculum, course_dat
             else
             {
                 grade.innerHTML = grade_list[i];
-                // GPA is affected by all letter grades except transfers (T)
-                curriculum.getSemester(semester.id).totalGPA += (courseCredit * letter_grades_global_dic[grade_list[i]]);
-                if(grade_list[i] != 'T'){
-                    curriculum.getSemester(semester.id).totalGPACredits += courseCredit;
-                }
-                // If grade is F, the course should not count towards earned credits
-                if(grade_list[i] == 'F'){
-                    let info = getInfo(courseCode, course_data);
-                    if(info){
-                        adjustSemesterTotals(curriculum.getSemester(semester.id), info, -1);
+                const gradeValue = letter_grades_global_dic[grade_list[i]];
+                if (gradeValue !== undefined) {
+                    // GPA is affected by all letter grades except transfers (T)
+                    curriculum.getSemester(semester.id).totalGPA += courseCredit * gradeValue;
+                    if (grade_list[i] !== 'T') {
+                        curriculum.getSemester(semester.id).totalGPACredits += courseCredit;
+                    }
+                    // If grade is F, the course should not count towards earned credits
+                    if (grade_list[i] === 'F') {
+                        let info = getInfo(courseCode, course_data);
+                        if (info) {
+                            adjustSemesterTotals(curriculum.getSemester(semester.id), info, -1);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Avoid subtracting undefined grade values when removing a course
- Guard GPA and credit tallies when updating or initializing course grades

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6895fb48047c832a96e096fce2da256a