### PR TITLE
feat: support course codes typed with spaces

### DIFF
--- a/scripts/click.js
+++ b/scripts/click.js
@@ -68,7 +68,12 @@ function dynamic_click(e, curriculum, course_data)
         function renderOptions(filter) {
             dropdown.innerHTML = '';
             const normalized = filter ? filter.toUpperCase() : '';
-            const filtered = options.filter(o => (o.code + ' ' + o.name).toUpperCase().includes(normalized));
+            const normalizedNoSpace = normalized.replace(/\s+/g, '');
+            const filtered = options.filter(o => {
+                const codeName = (o.code + ' ' + o.name).toUpperCase();
+                const codeNameNoSpace = (o.code + o.name).toUpperCase().replace(/\s+/g, '');
+                return codeName.includes(normalized) || codeNameNoSpace.includes(normalizedNoSpace);
+            });
             filtered.forEach(data => {
                 const opt = document.createElement('div');
                 opt.classList.add('course-option');
@@ -154,7 +159,12 @@ function dynamic_click(e, curriculum, course_data)
         // in both the primary major and the double major. If a match is
         // found, we derive the code accordingly.
         let inputValue = e.target.parentNode.querySelector("input").value.trim();
-        let tentativeCode = inputValue.split(' ')[0].toUpperCase();
+        let tokens = inputValue.split(/\s+/);
+        let tentativeCode = tokens[0] || '';
+        if (tokens.length > 1 && /\d/.test(tokens[1])) {
+            tentativeCode += tokens[1];
+        }
+        tentativeCode = tentativeCode.toUpperCase();
         let courseCode = tentativeCode;
         let courseObj = new s_course(courseCode, '');
         // Helper to search course by name in course_data and DM data

--- a/scripts/helper_functions.js
+++ b/scripts/helper_functions.js
@@ -1,9 +1,10 @@
 //checks wheter the course exists:
 function isCourseValid(course, course_data)
 {
+    const code = course && course.code ? course.code.replace(/\s+/g, '') : '';
     // First check within the main major's course data
     for (let i = 0; i < course_data.length; i++) {
-        if (((course_data[i]['Major'] + course_data[i]['Code']) === course.code)) return true;
+        if (((course_data[i]['Major'] + course_data[i]['Code']) === code)) return true;
     }
     // If not found and a double major is active, check the double major's
     // course catalog for this course code. The global curriculum object
@@ -13,7 +14,7 @@ function isCourseValid(course, course_data)
         if (cur && cur.doubleMajor && Array.isArray(cur.doubleMajorCourseData)) {
             const dmList = cur.doubleMajorCourseData;
             for (let i = 0; i < dmList.length; i++) {
-                if (((dmList[i]['Major'] + dmList[i]['Code']) === course.code)) {
+                if (((dmList[i]['Major'] + dmList[i]['Code']) === code)) {
                     return true;
                 }
             }
@@ -27,9 +28,10 @@ function isCourseValid(course, course_data)
 //returns info's of the course:
 function getInfo(course, course_data)
 {
+    const code = (course || '').replace(/\s+/g, '');
     // First search within the primary course data
     for (let i = 0; i < course_data.length; i++) {
-        if ((course_data[i]['Major'] + course_data[i]['Code']) === course) return course_data[i];
+        if ((course_data[i]['Major'] + course_data[i]['Code']) === code) return course_data[i];
     }
     // If not found and a double major is active, search within the double
     // major's catalog so that course details (name, credits) can be
@@ -41,7 +43,7 @@ function getInfo(course, course_data)
         if (cur && cur.doubleMajor && Array.isArray(cur.doubleMajorCourseData)) {
             const dmList = cur.doubleMajorCourseData;
             for (let i = 0; i < dmList.length; i++) {
-                if (((dmList[i]['Major'] + dmList[i]['Code']) === course)) {
+                if (((dmList[i]['Major'] + dmList[i]['Code']) === code)) {
                     return dmList[i];
                 }
             }


### PR DESCRIPTION
## Summary
- allow searching course codes with spaces by normalizing input
- join spaced tokens when adding courses via keyboard
- trim whitespace when validating or looking up course info

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0915da6a0832a920934cf7cfe4281